### PR TITLE
Add MmWaveVehicularHelper2  and ThreeGppAntennaArrayModel support in MmWaveSidelinkSpectrumPhy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ of 5G cellular and vehicular networks operating at mmWaves.
 
 Features:
 
-* The module provides integration of mmwave and millicar modules to simulate vehicular scenarios with Vehicle to Vehicle (V2V) and Vehicle to Infrastructure (V2I) communication.
+* The module provides an integration of mmwave and millicar modules to simulate vehicular scenarios with Vehicle to Vehicle (V2V) and Vehicle to Infrastructure (V2I) communication. This project is discribed in the related project paper, to get a copy please contact Andrea Manzato (GitHub: AndreaMnzt).
+
   
 ## Installation
 This repository contains a complete ns-3 installation with the addition of the mmwave and millicar modules. 
@@ -18,11 +19,26 @@ cd ns3-V2I-V2V
 ```
 
 ## Usage example 
-You can use the following command to run the `mmwave-simple-epc` example. 
-```
-./waf --run mmwave-simple-epc
-```
-Other examples are included in `src/mmwave/examples/`
+The following commands outputs SINR data and throughput data, which can be plot through the plot below,
+The SINR data are saved in the sinr-mcs.txt, which is the standard output file for the millicar module,
+
+1. Scenario A:
+
+./waf --run scratch/mmwave-vehicular-video-integration.cc
+
+plot:
+python3 millicar_video_plot_sinr.py
+// python3 throughput_video_plot.py //not used
+
+2. Scenario B:
+
+// The following command is not necessary:
+// you just need to run the first epc plot python script, which will run internally the 
+// ./waf --run scratch/mmwave-vehicular-epc-integration.cc 
+
+// plot ecp scripts:
+python3 millicar_epc_plot_sinr.py //this will also run the simulation
+python3 throughput_epc_plot.py 
 
 ## Related modules
 - MilliCar is an ns-3 module for the simulation of mmWave NR V2X networks. Check [this repo](https://github.com/signetlabdei/millicar) for further details.
@@ -66,6 +82,29 @@ The ns-3 mmWave module is the result of the development effort carried out by di
 - Russell Ford, NYU Wireless
 - Gabriel Arrobo, Intel
 
+The integration of MmWave and MilliCar modules in this repository was developed by Andrea Manzato, with the support of professors and assistants from University of Padua (UniPd).
+
 ## License ##
 
 This software is licensed under the terms of the GNU GPLv2, as like as ns-3. See the LICENSE file for more details.
+
+## Author Notes
+
+This extension was developed for the Network Analysis and Simulation course project. 
+The aim of the project is to integrate mmwave and millicar simulation in the same simulation script to evaluate interference effects.
+An example of the integration can be found in the following files:
+- Scenario A: scratch/mmwave-vehicular-video-integration.cc
+- Scenario B: scratch/mmwave-vehicular-epc-integration.cc
+This module DOES NOT integrate millicar and mmwave communication in the same node (e.g. a vehicle can still not communicate with an eNB),
+However this might be achieved by integrate mmwave and millicar netdevice instances in the same Node.
+
+If you need help to understand how this module was developed or you want to get in touch, please open an issue on this repository or PM me on LinkedIn.
+All files in this repository are distributed in the hope that they will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+This program is distributed under the same license and conditions of ns-3 simulator, MilliCar and MmWave module at 24 July 2022.
+
+Per aspera ad astra.
+Andrea Manzato

--- a/millicar_epc_plot_sinr.py
+++ b/millicar_epc_plot_sinr.py
@@ -1,0 +1,113 @@
+import os
+import time
+import matplotlib.pyplot as plt
+import numpy as np
+import operator
+import pandas as pd
+from random import randint
+
+### PARAMETERS TO DEFINE ###
+
+# Define if the simulation should restart or use old data in the sinr-mcs.txt traces file
+simulate = True
+
+# Define RNTI of the devices under analysis
+rnti_1 = '1'
+rnti_2 = '2'
+
+
+### SCRIPT ###
+
+if simulate: 
+  runs = [2]
+  print(f"RngRun: {runs}")
+
+  # Create a dictionary to record data for both devices
+  exp = {}
+  exp[rnti_1] = {}
+  exp[rnti_2] = {}
+
+  # Record data for each run to get an avarage at the end (when more runs are defined)
+  for rndrun in runs:
+    
+    # ns3 command line to run
+    ret = os.system(f'./waf --run "scratch/mmwave-vehicular-epc-integration.cc --rngrun={rndrun}"')
+    
+    print(f"Finished {rndrun}")
+
+    curr_out = open("sinr-mcs.txt")
+    
+    data = curr_out.readlines()
+    for line in data:
+      
+      # split the data to have simulation data
+      l = line.split()
+
+      # rnti of the device
+      dev = l[1]
+      
+      # timeslot of the sinr measurement
+      timeslot = float("{:.2f}".format(float(l[0])))
+      
+
+
+      ## Add Data to the data dictionaries
+      # Get data from dev with rnti 1
+      if dev == rnti_1:
+        
+        # add timeslot to data tictionary
+        if timeslot not in exp[rnti_1]:
+          exp[rnti_1][timeslot] = []  
+        exp[rnti_1][timeslot].append(l[2]) 
+
+      elif dev == rnti_2:      
+        if timeslot not in exp[rnti_2]:
+          exp[rnti_2][timeslot] = []  
+        exp[rnti_2][timeslot].append(l[2])
+      
+      else:
+        print("Rnti defined are not correct.")
+        exit()
+
+    curr_out.close()
+    time.sleep(1)
+
+  # elaborate data to get statistics
+  time_data = {}   
+  time_data[rnti_1] = []   
+  time_data[rnti_2] = []   
+
+
+  for dev in [rnti_1,rnti_2]:
+    for t in exp[dev]:
+      time_data[dev].append({
+                  "time":t,
+                  "sinr":np.mean([float(s) for s in exp[dev][t]]),
+                  "std":np.std([float(s) for s in exp[dev][t]]),
+                  "N":len([float(s) for s in exp[dev][t]])
+                  })
+
+  dev1_df = pd.DataFrame.from_dict(time_data[rnti_1])
+  dev2_df = pd.DataFrame.from_dict(time_data[rnti_2])
+  dev1_df.to_csv("dev1_df.csv")
+  dev2_df.to_csv("dev2_df.csv")
+
+dev1_df = pd.read_csv("dev1_df.csv")
+dev2_df = pd.read_csv("dev2_df.csv")
+
+
+dev1_df = dev1_df.sort_values('time')
+dev2_df = dev2_df.sort_values('time')
+#print(dev1_df)
+#print(dev2_df)
+
+# print final graph
+plt.figure()
+plt.plot(dev1_df['time'].values, dev1_df['sinr'].values, alpha=0.7, marker='x', label="SINR Vehicular Device 1")
+plt.plot(dev2_df['time'].values, dev2_df['sinr'].values, alpha=0.7, marker='x', label="SINR Vehicular Device 2")
+plt.legend()
+
+plt.ylabel("SINR [dB]")
+plt.xlabel("Time [s]")
+#plt.title("SNR, $x_{eNB}= x_{UE} = 80m, x_{UE}=-y_{eNB}=5m$")
+plt.show()

--- a/millicar_video_plot_sinr.py
+++ b/millicar_video_plot_sinr.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import matplotlib.pyplot as plt
+import re
+
+# to be runned after ./waf --run scratch/mmwave-vehicular-video-integration.cc 
+
+def main():
+
+  # time | rnti | 10 * std::log10 (sinrAvg) | numSym | tbSize | mcs 
+
+  f = open("sinr-mcs.txt")
+  lines = f.readlines()
+
+  times = {}
+  sinr = {}
+
+  #parse lines
+  for line in lines:
+    l = line.split()
+
+    if len(l) != 6:
+      print(f"ERROR, len={len(l)}")
+      exit
+
+    rnti = l[1]
+
+    # add times to times dictionary
+    if rnti not in times:
+      times[rnti] = []
+    
+    t = l[0]
+    times[rnti].append(float(t))
+
+    # add sirn to sinr dictionary
+    if rnti not in sinr:
+      sinr[rnti] = []
+    
+    s = l[2]
+    sinr[rnti].append(float(s))
+  
+  
+  plt.figure()
+  print(len(times['1']))
+  print(len(times['2']))
+
+  for rnti in ['1']:
+    plt.plot(times[rnti], sinr[rnti], alpha=0.5, marker='x', label="SINR Vehicular Device 1")
+
+  for rnti in ['2']:
+  
+    plt.plot(times[rnti], sinr[rnti], alpha=0.7, marker='x', label="SINR Vehicular Device 2")
+  
+
+  plt.legend()
+  #plt.title("SNR, $x_{eNB}= x_{UE} = 40m, x_{UE}=-y_{eNB}=10m$")
+
+  plt.ylabel("SINR [dB]")
+  plt.xlabel("Time [s]")
+  plt.show()
+
+
+  f.close()
+
+
+if __name__=="__main__":
+  main()
+

--- a/scratch/mmwave-vehicular-epc-integration.cc
+++ b/scratch/mmwave-vehicular-epc-integration.cc
@@ -1,0 +1,415 @@
+#include "ns3/mmwave-sidelink-spectrum-phy.h"
+#include "ns3/mmwave-vehicular-net-device.h"
+#include "ns3/mmwave-vehicular-helper2.h"
+#include "ns3/constant-position-mobility-model.h"
+#include "ns3/mobility-module.h"
+#include "ns3/isotropic-antenna-model.h"
+#include "ns3/spectrum-helper.h"
+#include "ns3/mmwave-spectrum-value-helper.h"
+#include "ns3/applications-module.h"
+#include "ns3/internet-module.h"
+#include "ns3/core-module.h"
+#include "ns3/node-list.h"
+
+#include <ns3/mmwave-helper.h>
+#include <ns3/mmwave-point-to-point-epc-helper.h>
+#include <ns3/point-to-point-helper.h>
+#include <ns3/buildings-helper.h>
+
+#include <ns3/mmwave-phy-mac-common.h>
+#include <ns3/mmwave-component-carrier.h>
+
+NS_LOG_COMPONENT_DEFINE ("v2epc");
+
+using namespace ns3;
+using namespace millicar;
+
+// this script creates two millicar vehicles moving horizontally
+// while a UE is trasmitting to a eNB connected to an EPC nearby
+
+uint32_t g_rxPackets = 0; // total number of received packets
+uint32_t g_txPackets; // total number of transmitted packets
+uint32_t g_clientrxPackets; // total number of received packets
+uint32_t g_old_rxPackets;
+uint32_t packetSize =1024; // UDP packet size in bytes
+
+u_int32_t deltaTime = 50; //milliseconds
+Time g_firstReceived; // timestamp of the first time a packet is received
+Time g_lastReceived; // timestamp of the last received packet
+
+static void Rx (Ptr<const Packet> p)
+{
+ g_rxPackets++;
+ if (g_rxPackets > 1)
+ {    
+    g_lastReceived = Simulator::Now();
+ }
+ else
+ {
+   g_firstReceived = Simulator::Now();
+ }
+
+}
+
+void ThroughputComputation (Ptr<OutputStreamWrapper> stream)
+{
+    *stream->GetStream ()<<Simulator::Now ().GetSeconds ()<<" , "<< ((g_rxPackets - g_old_rxPackets)*(double(packetSize)*8)/(double(deltaTime)/1000) )/1e6 << " Mbps " << g_rxPackets << std::endl;
+    g_old_rxPackets = g_rxPackets;
+    Simulator::Schedule( MilliSeconds(deltaTime), &ThroughputComputation, stream);
+}
+
+
+uint32_t g_rxPackets2 = 0; // total number of received packets
+uint32_t g_txPackets2; // total number of transmitted packets
+uint32_t g_clientrxPackets2; // total number of received packets
+uint32_t g_old_rxPackets2;
+
+Time g_firstReceived2; // timestamp of the first time a packet is received
+Time g_lastReceived2; // timestamp of the last received packet
+
+static void Rx2 (Ptr<const Packet> p)
+{
+ g_rxPackets2++;
+ if (g_rxPackets2 > 1)
+ {    
+    g_lastReceived2 = Simulator::Now();
+ }
+ else
+ {
+   g_firstReceived2 = Simulator::Now();
+ }
+
+}
+
+void ThroughputComputation2 (Ptr<OutputStreamWrapper> stream)
+{
+    *stream->GetStream ()<<Simulator::Now ().GetSeconds ()<<" , "<< ((g_rxPackets2 - g_old_rxPackets2)*(double(packetSize)*8)/(double(deltaTime)/1000) )/1e6 << " Mbps " << g_rxPackets2 << std::endl;
+    g_old_rxPackets2 = g_rxPackets2;
+    Simulator::Schedule( MilliSeconds(deltaTime), &ThroughputComputation2, stream);
+}
+
+int main (int argc, char *argv[])
+{
+
+  int seed = 31;
+  bool channel_shared = true;
+  RngSeedManager::SetRun (2);
+
+  
+  CommandLine cmd;
+  cmd.AddValue("rngrun", "Simulation run", seed);
+  cmd.Parse (argc, argv);
+  RngSeedManager::SetRun (seed);
+
+
+  // system parameters
+  double bandwidth = 100.0e6; // bandwidth in Hz
+  double frequency = 28e9; // the carrier frequency
+  uint32_t numerology = 3; // the numerologym
+
+  // applications
+  uint32_t packetSize = 1024; // UDP packet size in bytes
+  uint32_t startTime = 10; // application start time in milliseconds
+  uint32_t endTime = 8000; // application end time in milliseconds
+  uint32_t interPacketInterval = 10000; // interpacket interval in microseconds 1000
+
+  // mobility  
+  double speed = 20; // speed of the vehicles m/s
+  double intraGroupDistance = 20; // distance between two vehicles belonging to the same group
+  // double laneDistance = 5.0; // distance between the two lanes
+  double antennaHeight = 0; // the height of the antenna
+
+  // position mmwave and millicar 
+  double enb_x = 80;
+  double enb_y = -5;
+  double ue_x = 80;
+  double ue_y = 5;
+
+  double v1_x = 0;
+  double v1_y = 0;
+  double v2_x = 0 - intraGroupDistance;
+  double v2_y = 0;
+
+  Config::SetDefault ("ns3::MmWaveSidelinkMac::UseAmc", BooleanValue (true));
+  Config::SetDefault ("ns3::MmWavePhyMacCommon::CenterFreq", DoubleValue (frequency));
+  Config::SetDefault ("ns3::MmWaveVehicularHelper2::Bandwidth", DoubleValue (bandwidth));
+  Config::SetDefault ("ns3::MmWaveVehicularHelper2::Numerology", UintegerValue (numerology));
+  Config::SetDefault ("ns3::MmWaveVehicularPropagationLossModel::ChannelCondition", StringValue ("l"));
+  Config::SetDefault ("ns3::MmWaveVehicularPropagationLossModel::Shadowing", BooleanValue (true));
+  Config::SetDefault ("ns3::MmWaveVehicularSpectrumPropagationLossModel::UpdatePeriod", TimeValue (MilliSeconds (1)));
+  Config::SetDefault ("ns3::MmWaveVehicularAntennaArrayModel::AntennaElements", UintegerValue (4));
+  Config::SetDefault ("ns3::MmWaveVehicularAntennaArrayModel::AntennaElementPattern", StringValue ("3GPP-V2V"));
+  Config::SetDefault ("ns3::MmWaveVehicularAntennaArrayModel::IsotropicAntennaElements", BooleanValue (true));
+  Config::SetDefault ("ns3::MmWaveVehicularAntennaArrayModel::NumSectors", UintegerValue (16));
+  Config::SetDefault ("ns3::MmWaveVehicularNetDevice::RlcType", StringValue("LteRlcUm"));
+  Config::SetDefault ("ns3::MmWaveVehicularHelper2::SchedulingPatternOption", EnumValue(2)); // use 2 for SchedulingPatternOption=OPTIMIZED, 1 or SchedulingPatternOption=DEFAULT
+  Config::SetDefault ("ns3::LteRlcUm::MaxTxBufferSize", UintegerValue (500*1024));
+
+  // MMWAVE Setup
+
+  bool harqEnabled = true;
+  bool rlcAmEnabled = false;
+
+  Config::SetDefault ("ns3::MmWaveHelper::RlcAmEnabled", BooleanValue (rlcAmEnabled));
+  Config::SetDefault ("ns3::MmWaveHelper::HarqEnabled", BooleanValue (harqEnabled));
+  Config::SetDefault ("ns3::MmWaveFlexTtiMacScheduler::HarqEnabled", BooleanValue (harqEnabled));
+  Config::SetDefault ("ns3::LteRlcAm::ReportBufferStatusTimer", TimeValue (MicroSeconds (100.0)));
+  Config::SetDefault ("ns3::LteRlcUmLowLat::ReportBufferStatusTimer", TimeValue (MicroSeconds (100.0)));
+
+
+
+  unsigned numUe = 1;
+
+  Ptr<mmwave::MmWaveHelper> mmwave_helper = CreateObject<mmwave::MmWaveHelper> ();
+  mmwave_helper->SetSchedulerType ("ns3::MmWaveFlexTtiMacScheduler");
+  Ptr<mmwave::MmWavePointToPointEpcHelper>  epcHelper = CreateObject<mmwave::MmWavePointToPointEpcHelper> (); //created os
+  mmwave_helper->SetEpcHelper (epcHelper);
+  
+  mmwave_helper->SetHarqEnabled (harqEnabled);
+  
+
+  Ptr<Node> pgw = epcHelper->GetPgwNode ();
+
+  mmwave_helper->SetPathlossModelType("ns3::ThreeGppUmaPropagationLossModel");
+  mmwave_helper->SetChannelConditionModelType("ns3::ThreeGppUmaChannelConditionModel");
+
+
+  // Create a single RemoteHost
+  NodeContainer remoteHostContainer;
+  remoteHostContainer.Create (1);
+  Ptr<Node>  remoteHost = remoteHostContainer.Get (0);
+ 
+  InternetStackHelper internet;
+  internet.Install (remoteHostContainer);
+
+  // Create the Internet
+  PointToPointHelper p2ph;
+  p2ph.SetDeviceAttribute ("DataRate", DataRateValue (DataRate ("100Gb/s"))); // 100 
+  p2ph.SetDeviceAttribute ("Mtu", UintegerValue (1500));
+  p2ph.SetChannelAttribute ("Delay" , TimeValue (Seconds (0.010)) );//, TimeValue (Seconds (0.010)));
+  NetDeviceContainer internetDevices = p2ph.Install (pgw, remoteHost);
+  Ipv4AddressHelper ipv4h;
+  ipv4h.SetBase ("1.0.0.0", "255.0.0.0");
+  Ipv4InterfaceContainer internetIpIfaces = ipv4h.Assign (internetDevices);
+  // interface 0 is localhost, 1 is the p2p device
+  Ipv4Address remoteHostAddr = internetIpIfaces.GetAddress (1);
+
+  Ipv4StaticRoutingHelper ipv4RoutingHelper;
+  Ptr<Ipv4StaticRouting> remoteHostStaticRouting = ipv4RoutingHelper.GetStaticRouting (remoteHost->GetObject<Ipv4> ());
+  remoteHostStaticRouting->AddNetworkRouteTo (Ipv4Address ("7.0.0.0"), Ipv4Mask ("255.0.0.0"), 1);
+
+
+  NodeContainer enbNodes;
+  NodeContainer ueNodes;
+  enbNodes.Create (1);
+ 
+  ueNodes.Create (numUe);
+  
+  // eNB position
+  uint16_t enb_height = 0;
+  Ptr<ListPositionAllocator> enbPositionAlloc = CreateObject<ListPositionAllocator> ();
+  enbPositionAlloc->Add (Vector (enb_x, enb_y, enb_height));
+  MobilityHelper enbmobility;
+  enbmobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+  enbmobility.SetPositionAllocator (enbPositionAlloc);
+  enbmobility.Install (enbNodes);
+  BuildingsHelper::Install (enbNodes);
+
+  // UE position
+  MobilityHelper uemobility;
+  Ptr<ListPositionAllocator> uePositionAlloc = CreateObject<ListPositionAllocator> ();
+  uePositionAlloc->Add (Vector (ue_x, ue_y, antennaHeight));
+  uemobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+  uemobility.SetPositionAllocator (uePositionAlloc);
+  uemobility.Install (ueNodes);
+  
+  // install devices
+  NetDeviceContainer enbNetDev = mmwave_helper->InstallEnbDevice (enbNodes);
+  NetDeviceContainer ueNetDev = mmwave_helper->InstallUeDevice (ueNodes);
+
+
+
+  // Install the IP stack on the UEs
+  internet.Install (ueNodes);
+  Ipv4InterfaceContainer ueIpIface;
+  ueIpIface = epcHelper->AssignUeIpv4Address (NetDeviceContainer (ueNetDev));
+  
+  Ptr<Node> ueNode = ueNodes.Get (0);
+  Ptr<Ipv4StaticRouting> ueStaticRouting = ipv4RoutingHelper.GetStaticRouting (ueNode->GetObject<Ipv4> ());
+  ueStaticRouting->SetDefaultRoute (epcHelper->GetUeDefaultGatewayAddress (), 1);
+
+  
+
+  mmwave_helper->AttachToClosestEnb (ueNetDev, enbNetDev);
+  
+
+  // Install and start applications on UEs and remote host
+  uint16_t dlPort = 1235;
+  uint16_t ulPort = 2001;
+  uint16_t otherPort = 3001;
+  ApplicationContainer clientApps;
+  ApplicationContainer serverApps;
+  
+  PacketSinkHelper dlPacketSinkHelper ("ns3::UdpSocketFactory", InetSocketAddress (Ipv4Address::GetAny (), dlPort));
+  PacketSinkHelper ulPacketSinkHelper ("ns3::UdpSocketFactory", InetSocketAddress (Ipv4Address::GetAny (), ulPort));
+  PacketSinkHelper packetSinkHelper ("ns3::UdpSocketFactory", InetSocketAddress (Ipv4Address::GetAny (), otherPort));
+  serverApps.Add (dlPacketSinkHelper.Install (ueNodes.Get (0)));
+  serverApps.Add (ulPacketSinkHelper.Install (remoteHost));
+  serverApps.Add (packetSinkHelper.Install (ueNodes.Get (0)));
+
+  uint32_t mmwave_interpacket_time = 100;
+  UdpClientHelper dlClient (ueIpIface.GetAddress (0), dlPort);
+  dlClient.SetAttribute ("Interval", TimeValue (MicroSeconds (mmwave_interpacket_time)));
+  dlClient.SetAttribute ("MaxPackets", UintegerValue (1000000));
+
+  UdpClientHelper ulClient (remoteHostAddr, ulPort);
+  ulClient.SetAttribute ("Interval", TimeValue (MicroSeconds (mmwave_interpacket_time)));
+  ulClient.SetAttribute ("MaxPackets", UintegerValue (1000000));
+
+
+  clientApps.Add (dlClient.Install (remoteHost));
+  clientApps.Add (ulClient.Install (ueNodes.Get(0)));
+  
+  serverApps.Start (Seconds (1));
+  clientApps.Start (Seconds (1));
+
+  //mmwave_helper->EnableTraces ();
+  p2ph.EnablePcapAll ("mmwave-epc");
+
+  // millicar setup
+  // create the nodes
+  NodeContainer group1;
+  group1.Create (2);
+  
+
+  // create the mobility models
+  MobilityHelper mobility;
+  mobility.SetMobilityModel ("ns3::ConstantVelocityMobilityModel");
+  mobility.Install (group1);
+
+  group1.Get (0)->GetObject<MobilityModel> ()->SetPosition (Vector (v1_x, v1_y, antennaHeight));
+  group1.Get (0)->GetObject<ConstantVelocityMobilityModel> ()->SetVelocity (Vector (speed, 0, 0));
+
+  group1.Get (1)->GetObject<MobilityModel> ()->SetPosition (Vector (v2_x, v2_y, antennaHeight));
+  group1.Get (1)->GetObject<ConstantVelocityMobilityModel> ()->SetVelocity (Vector (speed, 0, 0));
+
+
+  // create and configure the helper
+  Ptr<MmWaveVehicularHelper2> helper = CreateObject<MmWaveVehicularHelper2> ();
+
+  // share the channel
+  if(channel_shared)
+  {
+    helper->SetSpectrumChannel(mmwave_helper->GetSpectrumChannel(0));
+    
+    helper->SetNumerology (numerology);
+    helper->SetPropagationLossModelType("ns3::MmWaveVehicularPropagationLossModel");
+    helper->SetSpectrumPropagationLossModelType("ns3::MmWaveVehicularSpectrumPropagationLossModel");
+
+    // choose the pathloss model to use
+    helper->SetPathlossModelType("ns3::ThreeGppUmaPropagationLossModel");
+
+    // choose the channel condition model to use
+    helper->SetChannelConditionModelType("ns3::ThreeGppUmaChannelConditionModel");
+
+    // choose the spectrum propagation loss model
+    helper->SetChannelModelType("ns3::ThreeGppSpectrumPropagationLossModel");
+
+    helper->SetSpectrumPropagationLossModelType("ns3::ThreeGppSpectrumPropagationLossModel");
+
+  } else {
+
+    helper->SetNumerology (numerology);
+    helper->SetPropagationLossModelType("ns3::MmWaveVehicularPropagationLossModel");
+    helper->SetSpectrumPropagationLossModelType("ns3::MmWaveVehicularSpectrumPropagationLossModel");
+
+    // choose the pathloss model to use
+    helper->SetPathlossModelType("ns3::ThreeGppUmaPropagationLossModel");
+
+    // choose the channel condition model to use
+    helper->SetChannelConditionModelType("ns3::ThreeGppUmaChannelConditionModel");
+
+    // choose the spectrum propagation loss model
+    helper->SetChannelModelType("ns3::ThreeGppSpectrumPropagationLossModel");
+
+    helper->SetSpectrumPropagationLossModelType("ns3::ThreeGppSpectrumPropagationLossModel");
+  }
+
+ 
+  NetDeviceContainer devs1 = helper->InstallMmWaveVehicularNetDevices (group1);
+
+  // Get rnti to print snri
+  //std::cout << "rnt car 1 "<< DynamicCast<MmWaveVehicularNetDevice>(devs1.Get(0))->GetMac()->GetRnti() << std::endl;
+  //std::cout << "rnt car 2 "<< DynamicCast<MmWaveVehicularNetDevice>(devs1.Get(1))->GetMac()->GetRnti() << std::endl;
+
+  // install the internet stack
+  InternetStackHelper internet2; 
+  internet2.Install (group1);
+  // assign the IP addresses
+  Ipv4AddressHelper ipv4;
+  ipv4.SetBase ("10.1.1.0", "255.255.255.0");
+  Ipv4InterfaceContainer i = ipv4.Assign (devs1);
+
+  
+  // connect the devices belonging to the same group
+  helper->PairDevices(devs1);
+  
+  Ipv4StaticRoutingHelper ipv4RoutingHelper2; 
+  Ptr<Ipv4StaticRouting> staticRouting = ipv4RoutingHelper2.GetStaticRouting (group1.Get (0)->GetObject<Ipv4> ());
+  staticRouting->SetDefaultRoute (group1.Get (1)->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal () , 2 );
+
+
+  // setup the applications
+  Config::SetDefault ("ns3::UdpClient::MaxPackets", UintegerValue (0xFFFFFFFF));
+  Config::SetDefault ("ns3::UdpClient::Interval", TimeValue (MicroSeconds (interPacketInterval)));
+  Config::SetDefault ("ns3::UdpClient::PacketSize", UintegerValue (packetSize));
+
+  // create the applications for group 1
+  uint32_t port = 4000;
+  UdpServerHelper server11 (port);
+  ApplicationContainer apps = server11.Install (group1.Get (1));
+
+  UdpServerHelper server10 (port);
+  apps.Add (server10.Install (group1.Get (0)));
+
+  UdpClientHelper client10 (group1.Get (1)->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal (), port);
+  apps.Add (client10.Install (group1.Get (0)));
+
+  UdpClientHelper client11 (group1.Get (0)->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal (), port);
+  apps.Add (client11.Install (group1.Get (1)));
+
+    // set the application start/end time
+  apps.Start (MilliSeconds (startTime));
+  apps.Stop (MilliSeconds (endTime));
+
+  AsciiTraceHelper asciiTraceHelper;
+  std::string filename;
+  if(channel_shared){
+    filename = "epc_throughput.txt";
+  } else {
+    filename = "epc_throughput-not-shared.txt";
+  }
+  Ptr<OutputStreamWrapper> stream = asciiTraceHelper.CreateFileStream (filename);
+  apps.Get(0)->TraceConnectWithoutContext ("Rx", MakeCallback (&Rx));
+  Simulator::Schedule(MilliSeconds(deltaTime), &ThroughputComputation, stream);
+
+
+  AsciiTraceHelper asciiTraceHelper2;
+  std::string filename2;
+  if(channel_shared){
+    filename2 = "epc_throughput2.txt";
+  } else {
+    filename2 = "epc_throughput-not-shared.txt2";
+  }
+  Ptr<OutputStreamWrapper> stream2 = asciiTraceHelper2.CreateFileStream (filename2);
+  apps.Get(1)->TraceConnectWithoutContext ("Rx", MakeCallback (&Rx2));
+  Simulator::Schedule(MilliSeconds(deltaTime), &ThroughputComputation2, stream2);
+
+ 
+  Simulator::Stop (MilliSeconds (endTime + 1000));
+  Simulator::Run ();
+  Simulator::Destroy ();
+
+  return 0;
+}
+

--- a/scratch/mmwave-vehicular-video-integration.cc
+++ b/scratch/mmwave-vehicular-video-integration.cc
@@ -282,9 +282,9 @@ int main (int argc, char *argv[])
   AsciiTraceHelper asciiTraceHelper;
   std::string filename;
   if(channel_shared){
-    filename = "voice_throughput.txt";
+    filename = "video_throughput.txt";
   } else {
-    filename = "voice_throughput-not-shared.txt";
+    filename = "video_throughput-not-shared.txt";
   }
   Ptr<OutputStreamWrapper> stream = asciiTraceHelper.CreateFileStream (filename);
   apps.Get(0)->TraceConnectWithoutContext ("Rx", MakeCallback (&Rx));

--- a/scratch/mmwave-vehicular-video-integration.cc
+++ b/scratch/mmwave-vehicular-video-integration.cc
@@ -1,0 +1,332 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+*   Copyright (c) 2020 University of Padova, Dep. of Information Engineering,
+*   SIGNET lab.
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License version 2 as
+*   published by the Free Software Foundation;
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program; if not, write to the Free Software
+*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#include "ns3/mmwave-sidelink-spectrum-phy.h"
+#include "ns3/mmwave-vehicular-net-device.h"
+#include "ns3/mmwave-vehicular-helper2.h"
+#include "ns3/constant-position-mobility-model.h"
+#include "ns3/mobility-module.h"
+#include "ns3/isotropic-antenna-model.h"
+#include "ns3/spectrum-helper.h"
+#include "ns3/mmwave-spectrum-value-helper.h"
+#include "ns3/applications-module.h"
+#include "ns3/internet-module.h"
+#include "ns3/core-module.h"
+#include "ns3/node-list.h"
+
+#include <ns3/mmwave-helper.h>
+#include <ns3/mmwave-point-to-point-epc-helper.h>
+#include <ns3/point-to-point-helper.h>
+#include <ns3/buildings-helper.h>
+
+NS_LOG_COMPONENT_DEFINE ("VehicularSimpleTwo");
+
+using namespace ns3;
+using namespace millicar;
+
+
+uint32_t g_rxPackets = 0; // total number of received packets
+uint32_t g_txPackets; // total number of transmitted packets
+uint32_t g_clientrxPackets; // total number of received packets
+uint32_t g_old_rxPackets;
+uint32_t packetSize =1024; // UDP packet size in bytes
+
+u_int32_t deltaTime = 50; //milliseconds
+Time g_firstReceived; // timestamp of the first time a packet is received
+Time g_lastReceived; // timestamp of the last received packet
+
+static void Rx (Ptr<const Packet> p)
+{
+ g_rxPackets++;
+ SeqTsHeader header;
+ p->PeekHeader(header);
+
+ if (g_rxPackets > 1)
+ {    
+    g_lastReceived = Simulator::Now();
+ }
+ else
+ {
+   g_firstReceived = Simulator::Now();
+ }
+
+}
+
+void ThroughputComputation (Ptr<OutputStreamWrapper> stream)
+{
+    *stream->GetStream ()<<Simulator::Now ().GetSeconds ()<<" , "<< ((g_rxPackets - g_old_rxPackets)*(double(packetSize)*8)/(double(deltaTime)/1000) )/1e6 << " Mbps " << g_rxPackets << std::endl;
+    g_old_rxPackets = g_rxPackets;
+    
+    Simulator::Schedule( MilliSeconds(deltaTime), &ThroughputComputation, stream);
+}
+
+void PrintGnuplottableNodeListToFile (std::string filename);
+int main (int argc, char *argv[])
+{ 
+ 
+  bool channel_shared = true;
+
+  SeedManager::SetSeed (1);
+  // system parameters
+  double bandwidth = 100.0e6; // bandwidth in Hz
+  double frequency = 28e9; // the carrier frequency
+  uint32_t numerology = 3; // the numerology
+
+  // applications
+  uint32_t packetSize =1024; // UDP packet size in bytes
+  uint32_t startTime = 50; // application start time in milliseconds
+  uint32_t endTime = 10000; // application end time in milliseconds
+  uint32_t interPacketInterval = 5000; // interpacket interval in microseconds (how much traffic)
+
+  // mobility
+  double speed = 20; // speed of the vehicles m/s
+  double intraGroupDistance = 10; // distance between two vehicles belonging to the same group
+  // double laneDistance = 5.0; // distance between the two lanes
+  double antennaHeight = 0.0; // the height of the antenna
+
+  // position
+  double enb_x = 100;
+  double enb_y = 5;
+  double ue_x = 100;
+  double ue_y = -5;
+
+  double v1_x = 0;
+  double v1_y = 0;
+  double v2_x = 0 - intraGroupDistance;
+  double v2_y = 0;
+
+  // TODO
+  // CommandLine cmd;
+  // cmd.AddValue ("vehicleSpeed", "The speed of the vehicle", speed);
+  // cmd.Parse (argc, argv);
+
+
+  Ptr<mmwave::MmWavePointToPointEpcHelper>  epcHelper = CreateObject<mmwave::MmWavePointToPointEpcHelper> ();
+
+  Config::SetDefault ("ns3::MmWaveSidelinkMac::UseAmc", BooleanValue (true));
+  Config::SetDefault ("ns3::MmWavePhyMacCommon::CenterFreq", DoubleValue (frequency));
+  Config::SetDefault ("ns3::MmWaveVehicularHelper2::Bandwidth", DoubleValue (bandwidth));
+  Config::SetDefault ("ns3::MmWaveVehicularHelper2::Numerology", UintegerValue (numerology));
+  Config::SetDefault ("ns3::MmWaveVehicularPropagationLossModel::ChannelCondition", StringValue ("l"));
+  Config::SetDefault ("ns3::MmWaveVehicularPropagationLossModel::Shadowing", BooleanValue (true));
+  Config::SetDefault ("ns3::MmWaveVehicularSpectrumPropagationLossModel::UpdatePeriod", TimeValue (MilliSeconds (1)));
+  Config::SetDefault ("ns3::MmWaveVehicularAntennaArrayModel::AntennaElements", UintegerValue (4));
+  Config::SetDefault ("ns3::MmWaveVehicularAntennaArrayModel::AntennaElementPattern", StringValue ("3GPP-V2V"));
+  Config::SetDefault ("ns3::MmWaveVehicularAntennaArrayModel::IsotropicAntennaElements", BooleanValue (true));
+  Config::SetDefault ("ns3::MmWaveVehicularAntennaArrayModel::NumSectors", UintegerValue (2));
+
+  Config::SetDefault ("ns3::MmWaveVehicularNetDevice::RlcType", StringValue("LteRlcUm"));
+  Config::SetDefault ("ns3::MmWaveVehicularHelper2::SchedulingPatternOption", EnumValue(2)); // use 2 for SchedulingPatternOption=OPTIMIZED, 1 or SchedulingPatternOption=DEFAULT
+  Config::SetDefault ("ns3::LteRlcUm::MaxTxBufferSize", UintegerValue (500*1024));
+
+  /////////////////////////////////////// MMWAVE
+  unsigned numUe = 1;
+
+  Ptr<mmwave::MmWaveHelper> mmwave_helper = CreateObject<mmwave::MmWaveHelper> ();
+  
+
+  NodeContainer enbNodes;
+  NodeContainer ueNodes;
+  enbNodes.Create (1);
+  ueNodes.Create (numUe);
+
+  
+  Ptr<ListPositionAllocator> enbPositionAlloc = CreateObject<ListPositionAllocator> ();
+  enbPositionAlloc->Add (Vector (enb_x, enb_y, antennaHeight));
+
+  MobilityHelper enbmobility;
+  enbmobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+  enbmobility.SetPositionAllocator (enbPositionAlloc);
+  enbmobility.Install (enbNodes);
+  BuildingsHelper::Install (enbNodes);
+
+  MobilityHelper uemobility;
+  Ptr<ListPositionAllocator> uePositionAlloc = CreateObject<ListPositionAllocator> ();
+  uePositionAlloc->Add (Vector (ue_x, ue_y, antennaHeight));
+
+  uemobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+  uemobility.SetPositionAllocator (uePositionAlloc);
+  uemobility.Install (ueNodes);
+  BuildingsHelper::Install (ueNodes);
+
+  NetDeviceContainer enbNetDev = mmwave_helper->InstallEnbDevice (enbNodes);
+  NetDeviceContainer ueNetDev = mmwave_helper->InstallUeDevice (ueNodes);
+
+
+  mmwave_helper->AttachToClosestEnb (ueNetDev, enbNetDev);
+  mmwave_helper->EnableTraces ();
+
+  // Activate a data radio bearer
+  enum EpsBearer::Qci q = EpsBearer::NGBR_VOICE_VIDEO_GAMING;
+  EpsBearer bearer (q); 
+  mmwave_helper->ActivateDataRadioBearer (ueNetDev, bearer);
+
+
+
+
+  ////////////////////////////////////// MILLICAR
+  // create the nodes
+  NodeContainer group1;
+  group1.Create (2);
+ 
+  // create the mobility models
+  MobilityHelper mobility;
+  mobility.SetMobilityModel ("ns3::ConstantVelocityMobilityModel");
+  mobility.Install (group1);
+
+  group1.Get (0)->GetObject<MobilityModel> ()->SetPosition (Vector (v1_x, v1_y, 0));
+  group1.Get (0)->GetObject<ConstantVelocityMobilityModel> ()->SetVelocity (Vector (speed, 0, 0));
+
+  group1.Get (1)->GetObject<MobilityModel> ()->SetPosition (Vector (v2_x, v2_y, 0));
+  group1.Get (1)->GetObject<ConstantVelocityMobilityModel> ()->SetVelocity (Vector (speed, 0, 0));
+
+
+  // create and configure the helper
+  Ptr<MmWaveVehicularHelper2> helper = CreateObject<MmWaveVehicularHelper2> ();
+
+  if(channel_shared)
+  {
+    helper->SetSpectrumChannel(mmwave_helper->GetSpectrumChannel(0));
+  }
+
+
+
+
+  helper->SetNumerology (numerology);
+  helper->SetPropagationLossModelType ("ns3::MmWaveVehicularPropagationLossModel");
+  helper->SetSpectrumPropagationLossModelType ("ns3::MmWaveVehicularSpectrumPropagationLossModel");
+
+// choose the pathloss model to use
+  helper->SetPathlossModelType ("ns3::ThreeGppUmaPropagationLossModel");
+
+  // choose the channel condition model to use
+  helper->SetChannelConditionModelType ("ns3::ThreeGppUmaChannelConditionModel");
+
+  // choose the spectrum propagation loss model
+  helper->SetChannelModelType ("ns3::ThreeGppSpectrumPropagationLossModel");
+  
+  helper->SetSpectrumPropagationLossModelType ("ns3::ThreeGppSpectrumPropagationLossModel");
+
+ 
+  // helper->SetSpectrumPropagationLossModelType ("ns3::FriisSpectrumPropagationLossModel");
+  NetDeviceContainer devs1 = helper->InstallMmWaveVehicularNetDevices (group1);
+  
+  // install the internet stack
+  InternetStackHelper internet2; //already declared
+  internet2.Install (group1);
+  
+  // assign the IP addresses
+  Ipv4AddressHelper ipv4;
+  ipv4.SetBase ("10.1.1.0", "255.255.255.0");
+  Ipv4InterfaceContainer i = ipv4.Assign (devs1);
+
+  
+  // connect the devices belonging to the same group
+  helper->PairDevices(devs1);
+  
+  Ipv4StaticRoutingHelper ipv4RoutingHelper2; //already declared
+
+  Ptr<Ipv4StaticRouting> staticRouting = ipv4RoutingHelper2.GetStaticRouting (group1.Get (0)->GetObject<Ipv4> ());
+  staticRouting->SetDefaultRoute (group1.Get (1)->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal () , 2 );
+
+  NS_LOG_DEBUG("IPv4 Address node 0 group 1: " << group1.Get (0)->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal ());
+  NS_LOG_DEBUG("IPv4 Address node 1 group 1: " << group1.Get (1)->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal ());
+
+  
+  
+  
+
+  // setup the applications
+  Config::SetDefault ("ns3::UdpClient::MaxPackets", UintegerValue (0xFFFFFFFF));
+  Config::SetDefault ("ns3::UdpClient::Interval", TimeValue (MicroSeconds (interPacketInterval)));
+  Config::SetDefault ("ns3::UdpClient::PacketSize", UintegerValue (packetSize));
+
+  // create the applications for group 1
+  uint32_t port = 4000;
+  UdpServerHelper server11 (port);
+  ApplicationContainer apps = server11.Install (group1.Get (1));
+
+  UdpServerHelper server10 (port);
+  apps.Add (server10.Install (group1.Get (0)));
+
+  UdpClientHelper client10 (group1.Get (1)->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal (), port);
+  apps.Add (client10.Install (group1.Get (0)));
+
+  UdpClientHelper client11 (group1.Get (0)->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal (), port);
+  apps.Add (client11.Install (group1.Get (1)));
+
+
+
+
+
+  // set the application start/end time
+  apps.Start (MilliSeconds (startTime));
+  apps.Stop (MilliSeconds (endTime));
+
+  AsciiTraceHelper asciiTraceHelper;
+  std::string filename;
+  if(channel_shared){
+    filename = "voice_throughput.txt";
+  } else {
+    filename = "voice_throughput-not-shared.txt";
+  }
+  Ptr<OutputStreamWrapper> stream = asciiTraceHelper.CreateFileStream (filename);
+  apps.Get(0)->TraceConnectWithoutContext ("Rx", MakeCallback (&Rx));
+  Simulator::Schedule(MilliSeconds(deltaTime), &ThroughputComputation, stream);
+
+
+  PrintGnuplottableNodeListToFile ("scenario.txt");
+
+  Simulator::Stop (MilliSeconds (endTime + 1000));
+  Simulator::Run ();
+  Simulator::Destroy ();
+
+  return 0;
+}
+
+void
+PrintGnuplottableNodeListToFile (std::string filename)
+{
+  std::ofstream outFile;
+  outFile.open (filename.c_str (), std::ios_base::out | std::ios_base::trunc);
+  if (!outFile.is_open ())
+    {
+      NS_LOG_ERROR ("Can't open file " << filename);
+      return;
+    }
+  outFile << "set xrange [-200:200]; set yrange [-200:200]" << std::endl;
+  for (NodeList::Iterator it = NodeList::Begin (); it != NodeList::End (); ++it)
+    {
+      Ptr<Node> node = *it;
+      int nDevs = node->GetNDevices ();
+      for (int j = 0; j < nDevs; j++)
+        {
+          Ptr<MmWaveVehicularNetDevice> vdev = node->GetDevice (j)->GetObject <MmWaveVehicularNetDevice> ();
+          if (vdev)
+            {
+              Vector pos = node->GetObject<MobilityModel> ()->GetPosition ();
+              outFile << "set label \"" << vdev->GetMac ()->GetRnti ()
+                      << "\" at "<< pos.x << "," << pos.y << " left font \"Helvetica,8\" textcolor rgb \"black\" front point pt 7 ps 0.3 lc rgb \"black\" offset 0,0"
+                      << std::endl;
+
+              // Simulator::Schedule (Seconds (1), &PrintHelper::UpdateGnuplottableNodeListToFile, filename, node);
+            }
+        }
+    }
+}

--- a/src/millicar/examples/v2x-example.cc
+++ b/src/millicar/examples/v2x-example.cc
@@ -1,0 +1,292 @@
+/* -*-  Mode: C++; c-file-style: "gnu"; indent-tabs-mode:nil; -*- */
+/*
+*   Copyright (c) 2011 Centre Tecnologic de Telecomunicacions de Catalunya (CTTC)
+*   Copyright (c) 2015, NYU WIRELESS, Tandon School of Engineering, New York University
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License version 2 as
+*   published by the Free Software Foundation;
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program; if not, write to the Free Software
+*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*
+*   Author: Marco Miozzo <marco.miozzo@cttc.es>
+*           Nicola Baldo  <nbaldo@cttc.es>
+*
+*   Modified by: Marco Mezzavilla < mezzavilla@nyu.edu>
+*                         Sourjya Dutta <sdutta@nyu.edu>
+*                         Russell Ford <russell.ford@nyu.edu>
+*                         Menglei Zhang <menglei@nyu.edu>
+*/  
+
+
+#include "ns3/core-module.h"
+#include "ns3/network-module.h"
+#include "ns3/mobility-module.h"
+#include "ns3/config-store.h"
+#include "ns3/mmwave-helper.h"
+#include <ns3/buildings-helper.h>
+#include "ns3/global-route-manager.h"
+#include "ns3/ipv4-global-routing-helper.h"
+#include "ns3/internet-module.h"
+#include "ns3/applications-module.h"
+#include "ns3/log.h"
+#include <ns3/mmwave-vehicular-helper2.h>
+#include <ns3/point-to-point-helper.h>
+
+#include <ns3/three-gpp-spectrum-propagation-loss-model.h>
+#include "ns3/channel-condition-model.h"
+
+using namespace ns3;
+using namespace mmwave;
+
+uint32_t g_rxPackets; // total number of received packets
+uint32_t g_txPackets; // total number of transmitted packets
+uint32_t g_clientrxPackets; // total number of received packets
+
+
+Time g_firstReceived; // timestamp of the first time a packet is received
+Time g_lastReceived; // timestamp of the last received packet
+
+static void Rx (Ptr<OutputStreamWrapper> stream, Ptr<const Packet> p)
+{
+ g_rxPackets++;
+ SeqTsHeader header;
+
+ p->PeekHeader(header);
+
+ *stream->GetStream () << Simulator::Now ().GetSeconds () << "\t" << p->GetSize() << "\t" << header.GetSeq() << "\t" << header.GetTs().GetSeconds() << std::endl;
+
+ if (g_rxPackets > 1)
+ {
+
+   g_lastReceived = Simulator::Now();
+ }
+ else
+ {
+   g_firstReceived = Simulator::Now();
+ }
+}
+
+static void Tx (Ptr<OutputStreamWrapper> stream, Ptr<const Packet> p)
+{
+ g_txPackets++;
+}
+
+
+static void echoRx (Ptr<OutputStreamWrapper> stream, Ptr<const Packet> p)
+{
+ g_clientrxPackets++;
+}
+
+int
+main (int argc, char *argv[])
+{
+
+  // mmwave setup
+
+  //CommandLine cmd;
+  //cmd.Parse (argc, argv);
+
+  /* Information regarding the traces generated:
+   *
+   * 1. UE_1_SINR.txt : Gives the SINR for each sub-band
+   *    Subframe no.  | Slot No. | Sub-band  | SINR (db)
+   *
+   * 2. UE_1_Tb_size.txt : Allocated transport block size
+   *    Time (micro-sec)  |  Tb-size in bytes
+   * */
+
+  NS_LOG_COMPONENT_DEFINE ("V2Xexample");
+
+  // system parameters
+  double bandwidth = 1e8; // bandwidth in Hz
+  double frequency = 28e9; // the carrier frequency
+  uint32_t numerology = 3; // the numerology
+
+  // applications
+  uint32_t packetSize = 1024; // UDP packet size in bytes
+  uint32_t startTime = 10; // application start time in milliseconds
+  uint32_t endTime = 500; // application end time in milliseconds
+  uint32_t interPacketInterval = 30; // interpacket interval in microseconds
+
+  // mobility
+  double speed = 20; // speed of the vehicles m/s
+  double intraGroupDistance = 1; // distance between two vehicles belonging to the same group
+
+  CommandLine cmd;
+  //
+  cmd.AddValue ("bandwidth", "used bandwidth", bandwidth);
+  cmd.AddValue ("iip", "inter packet interval, in microseconds", interPacketInterval);
+  cmd.AddValue ("intraGroupDistance", "distance between two vehicles belonging to the same group, y-coord", intraGroupDistance);
+  cmd.AddValue ("numerology", "set the numerology to use at the physical layer", numerology);
+  cmd.AddValue ("frequency", "set the carrier frequency", frequency);
+  cmd.Parse (argc, argv);
+
+
+  Config::SetDefault ("ns3::MmWaveSidelinkMac::UseAmc", BooleanValue (true));
+  Config::SetDefault ("ns3::MmWavePhyMacCommon::CenterFreq", DoubleValue (frequency));
+  Config::SetDefault ("ns3::MmWaveVehicularHelper2::Bandwidth", DoubleValue (bandwidth));
+  Config::SetDefault ("ns3::MmWaveVehicularHelper2::Numerology", UintegerValue (numerology));
+
+  Config::SetDefault ("ns3::MmWaveVehicularNetDevice::RlcType", StringValue("LteRlcUm"));
+  Config::SetDefault ("ns3::MmWaveVehicularHelper2::SchedulingPatternOption", EnumValue(2)); // use 2 for SchedulingPatternOption=OPTIMIZED, 1 or SchedulingPatternOption=DEFAULT
+  Config::SetDefault ("ns3::LteRlcUm::MaxTxBufferSize", UintegerValue (500*1024));
+
+
+  Ptr<MmWaveHelper> ptr_mmWave = CreateObject<MmWaveHelper> ();
+  
+  NodeContainer enbNodes;
+  NodeContainer ueNodes;
+  enbNodes.Create (1);
+  ueNodes.Create (1);
+
+  
+  Ptr<ListPositionAllocator> enbPositionAlloc = CreateObject<ListPositionAllocator> ();
+  enbPositionAlloc->Add (Vector (0.0, 0.0, 0.0));
+
+  MobilityHelper enbmobility;
+  enbmobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+  enbmobility.SetPositionAllocator (enbPositionAlloc);
+  enbmobility.Install (enbNodes);
+  BuildingsHelper::Install (enbNodes);
+
+  MobilityHelper uemobility;
+  Ptr<ListPositionAllocator> uePositionAlloc = CreateObject<ListPositionAllocator> ();
+  uePositionAlloc->Add (Vector (80.0, 0.0, 0.0));
+
+  uemobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+  uemobility.SetPositionAllocator (uePositionAlloc);
+  uemobility.Install (ueNodes);
+  BuildingsHelper::Install (ueNodes);
+  
+  NetDeviceContainer enbNetDev = ptr_mmWave->InstallEnbDevice (enbNodes);
+  NetDeviceContainer ueNetDev = ptr_mmWave->InstallUeDevice (ueNodes);
+
+  ptr_mmWave->AttachToClosestEnb (ueNetDev, enbNetDev);
+  ptr_mmWave->EnableTraces ();
+
+
+  // millicar setup 
+
+  // create the nodes
+  NodeContainer n;
+  n.Create (2);
+  // create the mobility models
+  MobilityHelper mobility;
+  mobility.SetMobilityModel ("ns3::ConstantVelocityMobilityModel");
+  mobility.Install (n);
+
+  n.Get (0)->GetObject<MobilityModel> ()->SetPosition (Vector (20,0,0));
+  n.Get (0)->GetObject<ConstantVelocityMobilityModel> ()->SetVelocity (Vector (0, speed, 0));
+
+  n.Get (1)->GetObject<MobilityModel> ()->SetPosition (Vector (20, intraGroupDistance,  0));
+  n.Get (1)->GetObject<ConstantVelocityMobilityModel> ()->SetVelocity (Vector (0, speed, 0));
+
+  // create and configure the helper
+  Ptr<millicar::MmWaveVehicularHelper2> helper = CreateObject<millicar::MmWaveVehicularHelper2> ();
+  
+  
+  helper->SetSpectrumChannel(ptr_mmWave->GetSpectrumChannel(0));
+  
+
+  // choose the spectrum propagation loss model
+  helper->SetNumerology (3);
+
+  helper->SetPropagationLossModelType ("ns3::ThreeGppPropagationLossModel");
+
+  // choose the pathloss model to use
+  helper->SetPathlossModelType ("ns3::ThreeGppUmaPropagationLossModel");
+
+  // choose the channel condition model to use
+  helper->SetChannelConditionModelType ("ns3::ThreeGppUmaChannelConditionModel");
+
+  // choose the spectrum propagation loss model
+  helper->SetChannelModelType ("ns3::ThreeGppSpectrumPropagationLossModel");
+  
+  helper->SetSpectrumPropagationLossModelType ("ns3::ThreeGppSpectrumPropagationLossModel");
+  NetDeviceContainer devs = helper->InstallMmWaveVehicularNetDevices (n);
+
+  // Install the TCP/IP stack in the two nodes
+
+  InternetStackHelper internet;
+  internet.Install (n);
+
+  Ipv4AddressHelper ipv4;
+  NS_LOG_INFO ("Assign IP Addresses.");
+  ipv4.SetBase ("10.1.1.0", "255.255.255.0");
+  Ipv4InterfaceContainer i = ipv4.Assign (devs);
+
+  // Need to pair the devices in order to create a correspondence between transmitter and receiver
+  // and to populate the < IP addr, RNTI > map.
+  helper->PairDevices(devs);
+
+  // Set the routing table
+  Ipv4StaticRoutingHelper ipv4RoutingHelper;
+  Ptr<Ipv4StaticRouting> staticRouting = ipv4RoutingHelper.GetStaticRouting (n.Get (0)->GetObject<Ipv4> ());
+  staticRouting->SetDefaultRoute (n.Get (1)->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal () , 2 );
+
+  NS_LOG_DEBUG("IPv4 Address node 0: " << n.Get (0)->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal ());
+  NS_LOG_DEBUG("IPv4 Address node 1: " << n.Get (1)->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal ());
+
+  Ptr<mmwave::MmWaveAmc> m_amc = CreateObject <mmwave::MmWaveAmc> (helper->GetConfigurationParameters());
+
+  // setup the applications
+  Config::SetDefault ("ns3::UdpEchoClient::MaxPackets", UintegerValue (0xFFFFFFFF));
+  Config::SetDefault ("ns3::UdpEchoClient::Interval", TimeValue (MicroSeconds (interPacketInterval)));
+  Config::SetDefault ("ns3::UdpEchoClient::PacketSize", UintegerValue (packetSize));
+
+  // create the applications
+  uint32_t port = 4000;
+
+  UdpEchoServerHelper server (port);
+  ApplicationContainer echoApps = server.Install (n.Get (1));
+  echoApps.Start (Seconds (0.0));
+
+  AsciiTraceHelper asciiTraceHelper;
+  Ptr<OutputStreamWrapper> stream = asciiTraceHelper.CreateFileStream ("simple-one-stats.txt");
+  echoApps.Get(0)->TraceConnectWithoutContext ("Rx", MakeBoundCallback (&Rx, stream));
+
+  UdpEchoClientHelper client (n.Get (1)->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal (), port);
+  ApplicationContainer apps = client.Install (n.Get (0));
+  
+  Ptr<OutputStreamWrapper> stream2 = asciiTraceHelper.CreateFileStream ("simple-two-stats.txt");
+  Ptr<OutputStreamWrapper> stream3 = asciiTraceHelper.CreateFileStream ("simple-three-stats.txt");
+
+
+  apps.Get(0)->TraceConnectWithoutContext("Tx", MakeBoundCallback(&Tx, stream2));
+  apps.Get(0)->TraceConnectWithoutContext("Rx", MakeBoundCallback(&echoRx, stream3));
+
+
+  // Activate a data radio bearer for mmwave devices
+  enum EpsBearer::Qci q = EpsBearer::GBR_CONV_VOICE;
+  EpsBearer bearer (q);
+  ptr_mmWave->ActivateDataRadioBearer (ueNetDev, bearer);
+
+  // set the application start/end time
+  apps.Start (MilliSeconds (startTime));
+
+  
+  
+  Simulator::Stop (MilliSeconds (endTime + 1000));
+  Simulator::Run ();
+  Simulator::Destroy ();
+
+  
+  std::cout << "----------- Statistics -----------" << std::endl;
+  std::cout << "Packets size:\t\t" << packetSize << " Bytes" << std::endl;
+  std::cout << "Packets received:\t" << g_rxPackets << std::endl;
+  std::cout << "Average Throughput:\t" << (double(g_rxPackets)*(double(packetSize)*8)/double( g_lastReceived.GetSeconds() - g_firstReceived.GetSeconds()))/1e6 << " Mbps" << std::endl;
+
+  std::cout << "Trasmitted: " << g_txPackets << std::endl;
+  std::cout << "Echo received: " << g_clientrxPackets << std::endl;
+
+
+  return 0;
+}

--- a/src/millicar/helper/mmwave-vehicular-helper2.cc
+++ b/src/millicar/helper/mmwave-vehicular-helper2.cc
@@ -22,7 +22,6 @@
 #include "ns3/double.h"
 #include "ns3/mmwave-vehicular-net-device.h"
 #include "ns3/internet-stack-helper.h"
-#include "ns3/single-model-spectrum-channel.h"
 #include "ns3/mmwave-vehicular-antenna-array-model.h"
 #include "ns3/pointer.h"
 #include "ns3/config.h"
@@ -270,6 +269,7 @@ MmWaveVehicularHelper2::InstallSingleMmWaveVehicularNetDevice (Ptr<Node> node, u
   bfModel->SetAttributeFailSafe ("ChannelModel", PointerValue (channelModel));
   ssp->SetBeamformingModel(bfModel);      
 
+  return device;
 }
 
 void

--- a/src/millicar/helper/mmwave-vehicular-helper2.cc
+++ b/src/millicar/helper/mmwave-vehicular-helper2.cc
@@ -1,0 +1,419 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+*   Copyright (c) 2020 University of Padova, Dep. of Information Engineering,
+*   SIGNET lab.
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License version 2 as
+*   published by the Free Software Foundation;
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program; if not, write to the Free Software
+*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#include "mmwave-vehicular-helper2.h"
+#include "ns3/log.h"
+#include "ns3/double.h"
+#include "ns3/mmwave-vehicular-net-device.h"
+#include "ns3/internet-stack-helper.h"
+#include "ns3/single-model-spectrum-channel.h"
+#include "ns3/mmwave-vehicular-antenna-array-model.h"
+#include "ns3/mmwave-vehicular-spectrum-propagation-loss-model.h"
+#include "ns3/pointer.h"
+#include "ns3/config.h"
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("MmWaveVehicularHelper2"); // TODO check if this has to be defined here
+
+namespace millicar {
+
+NS_OBJECT_ENSURE_REGISTERED (MmWaveVehicularHelper2); // TODO check if this has to be defined here
+
+MmWaveVehicularHelper2::MmWaveVehicularHelper2 ()
+: m_phyTraceHelper{CreateObject<MmWaveVehicularTracesHelper>("sinr-mcs.txt")} // TODO name as attribute
+{
+  NS_LOG_FUNCTION (this);
+}
+
+MmWaveVehicularHelper2::~MmWaveVehicularHelper2 ()
+{
+  NS_LOG_FUNCTION (this);
+}
+
+TypeId
+MmWaveVehicularHelper2::GetTypeId ()
+{
+  static TypeId tid =
+  TypeId ("ns3::MmWaveVehicularHelper2")
+  .SetParent<Object> ()
+  .AddConstructor<MmWaveVehicularHelper2> ()
+  .AddAttribute ("PropagationLossModel",
+                 "The type of path-loss model to be used. "
+                 "The allowed values for this attributes are the type names "
+                 "of any class inheriting from ns3::PropagationLossModel.",
+                 StringValue (""),
+                 MakeStringAccessor (&MmWaveVehicularHelper2::SetPropagationLossModelType),
+                 MakeStringChecker ())
+  .AddAttribute ("SpectrumPropagationLossModel",
+                 "The type of fast fading model to be used. "
+                 "The allowed values for this attributes are the type names "
+                 "of any class inheriting from ns3::SpectrumPropagationLossModel.",
+                 StringValue (""),
+                 MakeStringAccessor (&MmWaveVehicularHelper2::SetSpectrumPropagationLossModelType),
+                 MakeStringChecker ())
+  .AddAttribute ("PropagationDelayModel",
+                 "The type of propagation delay model to be used. "
+                 "The allowed values for this attributes are the type names "
+                 "of any class inheriting from ns3::PropagationDelayModel.",
+                 StringValue (""),
+                 MakeStringAccessor (&MmWaveVehicularHelper2::SetPropagationDelayModelType),
+                 MakeStringChecker ())
+  .AddAttribute ("Numerology",
+                 "Numerology to use for the definition of the frame structure."
+                 "2 : subcarrier spacing will be set to 60 KHz"
+                 "3 : subcarrier spacing will be set to 120 KHz",
+                 UintegerValue (2),
+                 MakeUintegerAccessor (&MmWaveVehicularHelper2::SetNumerology),
+                 MakeUintegerChecker<uint8_t> ())
+  .AddAttribute ("Bandwidth",
+                 "Bandwidth in Hz",
+                 DoubleValue (1e8),
+                 MakeDoubleAccessor (&MmWaveVehicularHelper2::m_bandwidth),
+                 MakeDoubleChecker<double> ())
+  .AddAttribute ("SchedulingPatternOption",
+                 "The type of scheduling pattern option to be used for resources assignation."
+                 "Default   : one single slot per subframe for each device"
+                 "Optimized : each slot of the subframe is used",
+                 EnumValue(DEFAULT),
+                 MakeEnumAccessor (&MmWaveVehicularHelper2::SetSchedulingPatternOptionType,
+                                   &MmWaveVehicularHelper2::GetSchedulingPatternOptionType),
+                 MakeEnumChecker(DEFAULT, "Default",
+                                 OPTIMIZED, "Optimized"))
+  ;
+
+  return tid;
+}
+
+void
+MmWaveVehicularHelper2::DoInitialize ()
+{
+  NS_LOG_FUNCTION (this);
+
+  // intialize the RNTI counter
+  m_rntiCounter = 0;
+  
+  // if the PHY layer configuration object was not set manually, create it 
+  if (!m_phyMacConfig)
+  {
+    m_phyMacConfig = CreateObjectWithAttributes<mmwave::MmWavePhyMacCommon> ("Numerology", EnumValue (m_numerologyIndex),   
+                                                                             "Bandwidth", DoubleValue (m_bandwidth));
+  }
+
+  // create the channel
+  m_channel = CreateObject<SingleModelSpectrumChannel> ();
+  if (!m_propagationLossModelType.empty ())
+  {
+    ObjectFactory factory (m_propagationLossModelType);
+    m_channel->AddPropagationLossModel (factory.Create<PropagationLossModel> ());
+  }
+  if (!m_spectrumPropagationLossModelType.empty ())
+  {
+    ObjectFactory factory (m_spectrumPropagationLossModelType);
+    m_channel->AddSpectrumPropagationLossModel (factory.Create<SpectrumPropagationLossModel> ());
+  }
+  if (!m_propagationDelayModelType.empty ())
+  {
+    ObjectFactory factory (m_propagationDelayModelType);
+    m_channel->SetPropagationDelayModel (factory.Create<PropagationDelayModel> ());
+  }
+
+  // 3GPP vehicular channel needs proper configuration
+  if (m_spectrumPropagationLossModelType == "ns3::MmWaveVehicularSpectrumPropagationLossModel")
+  {
+    Ptr<MmWaveVehicularSpectrumPropagationLossModel> threeGppSplm = DynamicCast<MmWaveVehicularSpectrumPropagationLossModel> (m_channel->GetSpectrumPropagationLossModel ());
+    PointerValue plm;
+    m_channel->GetAttribute ("PropagationLossModel", plm);
+    
+    Ptr<MmWaveVehicularPropagationLossModel> pathloss = DynamicCast<MmWaveVehicularPropagationLossModel> (plm.Get<PropagationLossModel> ());
+    pathloss->SetFrequency (m_phyMacConfig->GetCenterFrequency());
+    
+    threeGppSplm->SetPathlossModel (pathloss); // associate pathloss and fast fading models
+    threeGppSplm->SetFrequency (m_phyMacConfig->GetCenterFrequency()); // set correct value of frequency
+    
+  }
+}
+
+void
+MmWaveVehicularHelper2::SetConfigurationParameters (Ptr<mmwave::MmWavePhyMacCommon> conf)
+{
+  NS_LOG_FUNCTION (this);
+  NS_ASSERT_MSG (m_rntiCounter == 0, "The PHY configuration should be set before the installation of any device.");
+  m_phyMacConfig = conf;
+}
+
+Ptr<mmwave::MmWavePhyMacCommon>
+MmWaveVehicularHelper2::GetConfigurationParameters () const
+{
+  NS_LOG_FUNCTION (this);
+  return m_phyMacConfig;
+}
+
+void
+MmWaveVehicularHelper2::SetNumerology (uint8_t index)
+{
+  NS_LOG_FUNCTION (this);
+  m_numerologyIndex = index;
+}
+
+NetDeviceContainer
+MmWaveVehicularHelper2::InstallMmWaveVehicularNetDevices (NodeContainer nodes)
+{
+  NS_LOG_FUNCTION (this);
+
+  Initialize (); // run DoInitialize if necessary
+
+  NetDeviceContainer devices;
+  for (NodeContainer::Iterator i = nodes.Begin (); i != nodes.End (); ++i)
+    {
+      Ptr<Node> node = *i;
+
+      // create the device
+      Ptr<MmWaveVehicularNetDevice> device = InstallSingleMmWaveVehicularNetDevice (node, ++m_rntiCounter);
+
+      // assign an address
+      device->SetAddress (Mac64Address::Allocate ());
+
+      devices.Add (device);
+    }
+
+  return devices;
+}
+
+Ptr<MmWaveVehicularNetDevice>
+MmWaveVehicularHelper2::InstallSingleMmWaveVehicularNetDevice (Ptr<Node> node, uint16_t rnti)
+{
+  NS_LOG_FUNCTION (this);
+
+  // create the antenna
+  Ptr<MmWaveVehicularAntennaArrayModel> aam = CreateObject<MmWaveVehicularAntennaArrayModel> ();
+
+  // create and configure the tx spectrum phy
+  Ptr<MmWaveSidelinkSpectrumPhy> ssp = CreateObject<MmWaveSidelinkSpectrumPhy> ();
+  NS_ASSERT_MSG (node->GetObject<MobilityModel> (), "Missing mobility model");
+  ssp->SetMobility (node->GetObject<MobilityModel> ());
+  ssp->SetAntenna (aam);
+  NS_ASSERT_MSG (m_channel, "First create the channel");
+  ssp->SetChannel (m_channel);
+
+  // add the spectrum phy to the spectrum channel
+  m_channel->AddRx (ssp);
+
+  // create and configure the chunk processor
+  Ptr<mmwave::mmWaveChunkProcessor> pData = Create<mmwave::mmWaveChunkProcessor> ();
+  pData->AddCallback (MakeCallback (&MmWaveSidelinkSpectrumPhy::UpdateSinrPerceived, ssp));
+  ssp->AddDataSinrChunkProcessor (pData);
+
+  // create the phy
+  NS_ASSERT_MSG (m_phyMacConfig, "First set the configuration parameters");
+  Ptr<MmWaveSidelinkPhy> phy = CreateObject<MmWaveSidelinkPhy> (ssp, m_phyMacConfig);
+
+  // connect the rx callback of the spectrum object to the sink
+  ssp->SetPhyRxDataEndOkCallback (MakeCallback (&MmWaveSidelinkPhy::Receive, phy));
+
+  // connect the callback to report the SINR
+  ssp->SetSidelinkSinrReportCallback (MakeCallback (&MmWaveSidelinkPhy::GenerateSinrReport, phy));
+
+  if(m_phyTraceHelper != 0)
+  {
+    ssp->SetSidelinkSinrReportCallback (MakeCallback (&MmWaveVehicularTracesHelper::McsSinrCallback, m_phyTraceHelper));
+  }
+
+  // create the mac
+  Ptr<MmWaveSidelinkMac> mac = CreateObject<MmWaveSidelinkMac> (m_phyMacConfig);
+  mac->SetRnti (rnti);
+
+  // connect phy and mac
+  phy->SetPhySapUser (mac->GetPhySapUser ());
+  mac->SetPhySapProvider (phy->GetPhySapProvider ());
+
+  // create and configure the device
+  Ptr<MmWaveVehicularNetDevice> device = CreateObject<MmWaveVehicularNetDevice> (phy, mac);
+  node->AddDevice (device);
+  device->SetNode (node);
+  ssp->SetDevice (device);
+
+  // connect the rx callback of the mac object to the rx method of the NetDevice
+  mac->SetForwardUpCallback(MakeCallback(&MmWaveVehicularNetDevice::Receive, device));
+
+  // initialize the channel (if needed)
+  Ptr<MmWaveVehicularSpectrumPropagationLossModel> splm = DynamicCast<MmWaveVehicularSpectrumPropagationLossModel> (m_channel->GetSpectrumPropagationLossModel ());
+  if (splm)
+    splm->AddDevice (device, aam);
+
+  return device;
+}
+
+void
+MmWaveVehicularHelper2::PairDevices (NetDeviceContainer devices)
+{
+  NS_LOG_FUNCTION (this);
+
+  // TODO update this part to enable a more flexible configuration of the
+  // scheduling pattern
+
+  std::vector<uint16_t> pattern = CreateSchedulingPattern(devices);
+
+  uint8_t bearerId = 1;
+
+  for (NetDeviceContainer::Iterator i = devices.Begin (); i != devices.End (); ++i)
+    {
+
+      Ptr<MmWaveVehicularNetDevice> di = DynamicCast<MmWaveVehicularNetDevice> (*i);
+      Ptr<Node> iNode = di->GetNode ();
+      Ptr<Ipv4> iNodeIpv4 = iNode->GetObject<Ipv4> ();
+      NS_ASSERT_MSG (iNodeIpv4 != 0, "Nodes need to have IPv4 installed before pairing can be activated");
+
+      di->GetMac ()->SetSfAllocationInfo (pattern); // this is called ONCE for each NetDevice
+
+      for (NetDeviceContainer::Iterator j = i + 1; j != devices.End (); ++j)
+      {
+        Ptr<MmWaveVehicularNetDevice> dj = DynamicCast<MmWaveVehicularNetDevice> (*j);
+        Ptr<Node> jNode = dj->GetNode ();
+        Ptr<Ipv4> jNodeIpv4 = jNode->GetObject<Ipv4> ();
+        NS_ASSERT_MSG (jNodeIpv4 != 0, "Nodes need to have IPv4 installed before pairing can be activated");
+
+        // initialize the <IP address, RNTI> map of the devices
+        int32_t interface =  jNodeIpv4->GetInterfaceForDevice (dj);
+        Ipv4Address diAddr = iNodeIpv4->GetAddress (interface, 0).GetLocal ();
+        Ipv4Address djAddr = jNodeIpv4->GetAddress (interface, 0).GetLocal ();
+
+        // register the associated devices in the PHY
+        di->GetPhy ()->AddDevice (dj->GetMac ()->GetRnti (), dj);
+        dj->GetPhy ()->AddDevice (di->GetMac ()->GetRnti (), di);
+
+        // bearer activation by creating a logical channel between the two devices
+        NS_LOG_DEBUG("Activation of bearer between " << diAddr << " and " << djAddr);
+        NS_LOG_DEBUG("Bearer ID: " << uint32_t(bearerId) << " - Associate RNTI " << di->GetMac ()->GetRnti () << " to " << dj->GetMac ()->GetRnti ());
+
+        di->ActivateBearer(bearerId, dj->GetMac ()->GetRnti (), djAddr);
+        dj->ActivateBearer(bearerId, di->GetMac ()->GetRnti (), diAddr);
+        bearerId++;
+      }
+
+
+    }
+}
+
+std::vector<uint16_t>
+MmWaveVehicularHelper2::CreateSchedulingPattern (NetDeviceContainer devices)
+{
+  // The maximum supported number of vehicles in the group is equal to the available number of slots per subframe
+  // TODO implement scheduling pattern that support groups with a number of vehicle greater than the number of slots per subframe
+  NS_ABORT_MSG_IF (devices.GetN () > m_phyMacConfig->GetSlotsPerSubframe (), "Too many devices");
+
+  // NOTE fixed scheduling pattern, set in configuration time and assumed the same for each subframe
+
+  uint8_t slotPerSf = m_phyMacConfig->GetSlotsPerSubframe ();
+  std::vector<uint16_t> pattern;
+
+  switch (m_schedulingOpt)
+  {
+    case DEFAULT:
+    {
+      // Each slot in the subframe is assigned to a different user.
+      // If (numDevices < numSlots), the remaining available slots are unused
+      pattern = std::vector<uint16_t> (slotPerSf);
+      for (uint16_t i = 0; i < devices.GetN (); i++)
+      {
+        Ptr<MmWaveVehicularNetDevice> di = DynamicCast<MmWaveVehicularNetDevice> (devices.Get (i));
+        pattern.at(i) = di->GetMac ()->GetRnti ();
+        NS_LOG_DEBUG ("slot " << i << " assigned to rnti " << di->GetMac ()->GetRnti ());
+      }
+      break;
+    }
+    case OPTIMIZED:
+    {
+      // Each slot in the subframe is used
+      uint8_t slotPerDev = std::floor ( slotPerSf / devices.GetN ());
+      uint8_t remainingSlots = slotPerSf % devices.GetN ();
+
+      NS_LOG_DEBUG("Minimum number of slots per device = " << (uint16_t)slotPerDev);
+      NS_LOG_DEBUG("Available slots = " << (uint16_t)slotPerSf);
+
+      uint8_t slotCnt = 0;
+
+      for (uint16_t i = 0; i < devices.GetN (); i++)
+      {
+        Ptr<MmWaveVehicularNetDevice> di = DynamicCast<MmWaveVehicularNetDevice> (devices.Get (i));
+
+        for (uint8_t j = 0; j < slotPerDev; j++)
+        {
+          pattern.push_back(di->GetMac ()->GetRnti ());
+          NS_LOG_DEBUG ("slot " << uint16_t(slotCnt) << " assigned to rnti " << di->GetMac ()->GetRnti ());
+          slotCnt++;
+        }
+      }
+
+      NS_LOG_DEBUG("Remaining slots = " << (uint16_t)remainingSlots);
+      for (uint16_t i = 0; i < remainingSlots; i++)
+      {
+        Ptr<MmWaveVehicularNetDevice> di = DynamicCast<MmWaveVehicularNetDevice> (devices.Get (i));
+        pattern.push_back(di->GetMac ()->GetRnti ());
+        NS_LOG_DEBUG ("slot " << uint16_t(slotCnt) << " assigned to rnti " << di->GetMac ()->GetRnti ());
+        slotCnt++;
+      }
+      break;
+    }
+    default:
+    {
+      NS_FATAL_ERROR("Programming Error.");
+    }
+  }
+
+  return pattern;
+}
+
+void
+MmWaveVehicularHelper2::SetPropagationLossModelType (std::string plm)
+{
+  NS_LOG_FUNCTION (this);
+  m_propagationLossModelType = plm;
+}
+
+void
+MmWaveVehicularHelper2::SetSpectrumPropagationLossModelType (std::string splm)
+{
+  NS_LOG_FUNCTION (this);
+  m_spectrumPropagationLossModelType = splm;
+}
+
+void
+MmWaveVehicularHelper2::SetPropagationDelayModelType (std::string pdm)
+{
+  NS_LOG_FUNCTION (this);
+  m_propagationDelayModelType = pdm;
+}
+
+void
+MmWaveVehicularHelper2::SetSchedulingPatternOptionType (SchedulingPatternOption_t spo)
+{
+  NS_LOG_FUNCTION (this);
+  m_schedulingOpt = spo;
+}
+
+MmWaveVehicularHelper2::SchedulingPatternOption_t
+MmWaveVehicularHelper2::GetSchedulingPatternOptionType () const
+{
+  NS_LOG_FUNCTION (this);
+  return m_schedulingOpt;
+}
+
+} // namespace millicar
+} // namespace ns3

--- a/src/millicar/helper/mmwave-vehicular-helper2.cc
+++ b/src/millicar/helper/mmwave-vehicular-helper2.cc
@@ -200,7 +200,6 @@ MmWaveVehicularHelper2::InstallSingleMmWaveVehicularNetDevice (Ptr<Node> node, u
   NS_LOG_FUNCTION (this);
 
   // create the antenna
-  Ptr<MmWaveVehicularAntennaArrayModel> aam = CreateObject<MmWaveVehicularAntennaArrayModel> ();
   u_int16_t AntennaNum = 16;
   Ptr<ThreeGppAntennaArrayModel> antenna = CreateObjectWithAttributes<ThreeGppAntennaArrayModel> ("NumRows", UintegerValue (sqrt (AntennaNum)), "NumColumns", UintegerValue (sqrt (AntennaNum)));
 
@@ -210,7 +209,8 @@ MmWaveVehicularHelper2::InstallSingleMmWaveVehicularNetDevice (Ptr<Node> node, u
   Ptr<MmWaveSidelinkSpectrumPhy> ssp = CreateObject<MmWaveSidelinkSpectrumPhy> ();
   NS_ASSERT_MSG (node->GetObject<MobilityModel> (), "Missing mobility model");
   ssp->SetMobility (node->GetObject<MobilityModel> ());
-  //ssp->SetAntenna (aam);
+  ssp->UseGppAntenna(true);
+  ssp->SetThreeGppAntenna(antenna);
   NS_ASSERT_MSG (m_channel, "First create the channel");
   ssp->SetChannel (m_channel);
 
@@ -262,6 +262,13 @@ MmWaveVehicularHelper2::InstallSingleMmWaveVehicularNetDevice (Ptr<Node> node, u
   {
     threeGppSplm->AddDevice (device, antenna);
   }
+
+  auto channelModel = threeGppSplm->GetChannelModel();
+  Ptr<mmwave::MmWaveBeamformingModel> bfModel = m_bfModelFactory.Create<mmwave::MmWaveBeamformingModel> ();
+  bfModel->SetAttributeFailSafe ("Device", PointerValue (device));
+  bfModel->SetAttributeFailSafe ("Antenna", PointerValue (antenna));
+  bfModel->SetAttributeFailSafe ("ChannelModel", PointerValue (channelModel));
+  ssp->SetBeamformingModel(bfModel);      
 
 }
 

--- a/src/millicar/helper/mmwave-vehicular-helper2.cc
+++ b/src/millicar/helper/mmwave-vehicular-helper2.cc
@@ -208,7 +208,7 @@ MmWaveVehicularHelper2::InstallSingleMmWaveVehicularNetDevice (Ptr<Node> node, u
   Ptr<MmWaveSidelinkSpectrumPhy> ssp = CreateObject<MmWaveSidelinkSpectrumPhy> ();
   NS_ASSERT_MSG (node->GetObject<MobilityModel> (), "Missing mobility model");
   ssp->SetMobility (node->GetObject<MobilityModel> ());
-  ssp->UseGppAntenna(true);
+  ssp->UseThreeGppAntenna(true);
   ssp->SetThreeGppAntenna(antenna);
   NS_ASSERT_MSG (m_channel, "First create the channel");
   ssp->SetChannel (m_channel);

--- a/src/millicar/helper/mmwave-vehicular-helper2.cc
+++ b/src/millicar/helper/mmwave-vehicular-helper2.cc
@@ -141,37 +141,8 @@ MmWaveVehicularHelper2::DoInitialize ()
                                                                              "Bandwidth", DoubleValue (m_bandwidth));
   }
 
-  // create the channel
-  m_channel = CreateObject<SingleModelSpectrumChannel> ();
-  if (!m_propagationLossModelType.empty ())
-  {
-    ObjectFactory factory (m_propagationLossModelType);
-    m_channel->AddPropagationLossModel (factory.Create<PropagationLossModel> ());
-  }
-  if (!m_spectrumPropagationLossModelType.empty ())
-  {
-    ObjectFactory factory (m_spectrumPropagationLossModelType);
-    m_channel->AddSpectrumPropagationLossModel (factory.Create<SpectrumPropagationLossModel> ());
-  }
-  if (!m_propagationDelayModelType.empty ())
-  {
-    ObjectFactory factory (m_propagationDelayModelType);
-    m_channel->SetPropagationDelayModel (factory.Create<PropagationDelayModel> ());
-  }
-
-  // 3GPP vehicular channel needs proper configuration
-  if (m_spectrumPropagationLossModelType == "ns3::MmWaveVehicularSpectrumPropagationLossModel")
-  {
-    Ptr<MmWaveVehicularSpectrumPropagationLossModel> threeGppSplm = DynamicCast<MmWaveVehicularSpectrumPropagationLossModel> (m_channel->GetSpectrumPropagationLossModel ());
-    PointerValue plm;
-    m_channel->GetAttribute ("PropagationLossModel", plm);
-    
-    Ptr<MmWaveVehicularPropagationLossModel> pathloss = DynamicCast<MmWaveVehicularPropagationLossModel> (plm.Get<PropagationLossModel> ());
-    pathloss->SetFrequency (m_phyMacConfig->GetCenterFrequency());
-    
-    threeGppSplm->SetPathlossModel (pathloss); // associate pathloss and fast fading models
-    threeGppSplm->SetFrequency (m_phyMacConfig->GetCenterFrequency()); // set correct value of frequency
-    
+  if (!m_channel){
+    MmWaveChannelModelInitialization ();      // channel initialization
   }
 }
 

--- a/src/millicar/helper/mmwave-vehicular-helper2.h
+++ b/src/millicar/helper/mmwave-vehicular-helper2.h
@@ -20,12 +20,12 @@
 #ifndef MMWAVE_VEHICULAR_HELPER_H2
 #define MMWAVE_VEHICULAR_HELPER_H2
 
-#include "ns3/mmwave-vehicular.h"
 #include "ns3/node-container.h"
 #include "ns3/net-device-container.h"
 #include "ns3/spectrum-channel.h"
 #include "ns3/mmwave-phy-mac-common.h"
 #include "ns3/mmwave-vehicular-traces-helper.h"
+#include <ns3/cc-helper.h>
 
 namespace ns3 {
 
@@ -152,6 +152,12 @@ private:
   SchedulingPatternOption_t m_schedulingOpt; //!< the type of scheduling pattern policy to be adopted
 
   Ptr<MmWaveVehicularTracesHelper> m_phyTraceHelper; //!< Ptr to an helper for the physical layer traces
+
+  ObjectFactory m_channelConditionModelFactory; //!< the factory for the ChannelConditionModel objects
+  ObjectFactory m_spectrumPropagationLossModelFactory; //!< the factory for the SpectrumPropagationLossModel objects
+  ObjectFactory m_pathlossModelFactory; //!< the factory for the PathLossModel objects
+  ObjectFactory m_channelFactory; //!< the factory for the ChannelModel objects
+  ObjectFactory m_bfModelFactory; //!< the factory for the BeaformingModel objects
 
 };
 

--- a/src/millicar/helper/mmwave-vehicular-helper2.h
+++ b/src/millicar/helper/mmwave-vehicular-helper2.h
@@ -1,0 +1,161 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+*   Copyright (c) 2020 University of Padova, Dep. of Information Engineering,
+*   SIGNET lab.
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License version 2 as
+*   published by the Free Software Foundation;
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program; if not, write to the Free Software
+*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#ifndef MMWAVE_VEHICULAR_HELPER_H2
+#define MMWAVE_VEHICULAR_HELPER_H2
+
+#include "ns3/mmwave-vehicular.h"
+#include "ns3/node-container.h"
+#include "ns3/net-device-container.h"
+#include "ns3/spectrum-channel.h"
+#include "ns3/mmwave-phy-mac-common.h"
+#include "ns3/mmwave-vehicular-traces-helper.h"
+
+namespace ns3 {
+
+namespace millicar {
+
+class MmWaveVehicularNetDevice;
+
+/**
+ * This class is used for the creation of MmWaveVehicularNetDevices and
+ * their configuration
+ */
+
+class MmWaveVehicularHelper2 : public Object
+{
+public:
+  /**
+   * Constructor
+   */
+  MmWaveVehicularHelper2 (void);
+
+  /**
+   * Destructor
+   */
+  virtual ~MmWaveVehicularHelper2 (void);
+
+  // inherited from Object
+  static TypeId GetTypeId (void);
+
+  /**
+   * Install a MmWaveVehicularNetDevice on each node in the container
+   * \param nodes the node container
+   * \return a NetDeviceContainer containing the installed devices
+   */
+  NetDeviceContainer InstallMmWaveVehicularNetDevices (NodeContainer nodes);
+
+  /**
+   * Set the configuration parameters
+   * \param conf pointer to mmwave::MmWavePhyMacCommon
+   */
+  void SetConfigurationParameters (Ptr<mmwave::MmWavePhyMacCommon> conf);
+
+  /**
+   * Retrieve pointer to the object that lists all the configuration parameters
+   * \return a pointer to a MmWavePhyMacCommon object
+   */
+  Ptr<mmwave::MmWavePhyMacCommon> GetConfigurationParameters () const;
+
+  /**
+   * Set the propagation loss model type
+   * \param plm the type id of the propagation loss model to use
+   */
+  void SetPropagationLossModelType (std::string plm);
+
+  /**
+   * Set the spectrum propagation loss model type
+   * \param splm the type id of the spectrum propagation loss model to use
+   */
+  void SetSpectrumPropagationLossModelType (std::string splm);
+
+  /**
+   * Set the propagation delay model type
+   * \param pdm the type id of the propagation delay model to use
+   */
+  void SetPropagationDelayModelType (std::string pdm);
+
+  /**
+   * Associate the devices in the container
+   * \param devices the NetDeviceContainer with the devices
+   */
+  void PairDevices (NetDeviceContainer devices);
+
+  /**
+   * Configure the numerology index
+   * \param index numerology index, used to define PHY layer parameters
+   */
+  void SetNumerology (uint8_t index);
+
+  /**
+   * Configure the scheduling pattern for a specific group of devices
+   * \param devices the NetDeviceContainer with the devices
+   * \return a vector of integers representing the scheduling pattern
+  */
+  std::vector<uint16_t> CreateSchedulingPattern (NetDeviceContainer devices);
+
+  /**
+   * Identifies the supported scheduling pattern policies
+   */
+  enum SchedulingPatternOption_t {DEFAULT = 1,
+                                   OPTIMIZED = 2};
+
+  /**
+  * Set the scheduling pattern option type
+  * \param spo the enum representing the scheduling pattern policy to be adopted
+  */
+  void SetSchedulingPatternOptionType (SchedulingPatternOption_t spo);
+
+  /**
+  * Returns the adopted scheduling pattern policy
+  * \return the adopted scheduling pattern policy
+  */
+  SchedulingPatternOption_t GetSchedulingPatternOptionType () const;
+
+protected:
+  // inherited from Object
+  virtual void DoInitialize (void) override;
+
+private:
+  /**
+   * Install a MmWaveVehicularNetDevice on the node
+   * \param n the node
+   * \param rnti the RNTI
+   * \return pointer to the installed NetDevice
+   */
+  Ptr<MmWaveVehicularNetDevice> InstallSingleMmWaveVehicularNetDevice (Ptr<Node> n, uint16_t rnti);
+
+  Ptr<SpectrumChannel> m_channel; //!< the SpectrumChannel
+  Ptr<mmwave::MmWavePhyMacCommon> m_phyMacConfig; //!< the configuration parameters
+  uint16_t m_rntiCounter; //!< a counter to set the RNTIs
+  uint8_t m_numerologyIndex; //!< numerology index
+  double m_bandwidth; //!< system bandwidth
+  std::string m_propagationLossModelType; //!< the type id of the propagation loss model to be used
+  std::string m_spectrumPropagationLossModelType; //!< the type id of the spectrum propagation loss model to be used
+  std::string m_propagationDelayModelType; //!< the type id of the delay model to be used
+  SchedulingPatternOption_t m_schedulingOpt; //!< the type of scheduling pattern policy to be adopted
+
+  Ptr<MmWaveVehicularTracesHelper> m_phyTraceHelper; //!< Ptr to an helper for the physical layer traces
+
+};
+
+} // namespace millicar
+} // namespace ns3
+
+#endif /* MMWAVE_VEHICULAR_HELPER_H2 */

--- a/src/millicar/helper/mmwave-vehicular-helper2.h
+++ b/src/millicar/helper/mmwave-vehicular-helper2.h
@@ -173,7 +173,7 @@ public:
 
   
 
-  //void MmWaveChannelModelInitialization (void);
+  void MmWaveChannelModelInitialization (void);
 
   
 protected:

--- a/src/millicar/helper/mmwave-vehicular-helper2.h
+++ b/src/millicar/helper/mmwave-vehicular-helper2.h
@@ -128,6 +128,54 @@ public:
   */
   SchedulingPatternOption_t GetSchedulingPatternOptionType () const;
 
+  /// New Methods ///
+
+  // spectrum propagation Loss model methods
+
+  void SetChannelModelType (std::string type);
+
+  void SetChannelModelAttribute (std::string name, const AttributeValue &value);
+
+  // channel condition model methods
+
+  void SetChannelConditionModelType (std::string type);
+
+  // pathloss methods
+
+  void SetPathlossModelType (std::string type);
+
+  Ptr<PropagationLossModel> GetPathLossModel (void);
+
+  // beamforming methods
+  
+  /**
+   * Set the type of beamforming model to be used
+   * \param type beamforming model type
+   */
+
+  void SetBeamformingModelType (std::string type);
+
+  /**
+   * Set an attribute to the MmWaveBeamformingModel
+   * \param name name of the attribute to set
+   * \param value value to set
+   */
+  
+  void SetBeamformingModelAttribute (std::string name, const AttributeValue &value);
+  
+  // Spectrum Channel methods
+
+  void SetSpectrumChannel (Ptr<ns3::SpectrumChannel> channel);
+  
+  Ptr<SpectrumChannel> GetSpectrumChannel ();
+
+  
+
+  
+
+  //void MmWaveChannelModelInitialization (void);
+
+  
 protected:
   // inherited from Object
   virtual void DoInitialize (void) override;
@@ -153,6 +201,10 @@ private:
 
   Ptr<MmWaveVehicularTracesHelper> m_phyTraceHelper; //!< Ptr to an helper for the physical layer traces
 
+  std::string m_channelConditionModelType; //!< the type of the channel condition model to be used (empty string means no channel condition model)
+  std::string m_pathlossModelType; //!< the type of the path loss model to be used (empty string means no channel condition model)
+  Ptr<Object> m_pathlossModel;
+  
   ObjectFactory m_channelConditionModelFactory; //!< the factory for the ChannelConditionModel objects
   ObjectFactory m_spectrumPropagationLossModelFactory; //!< the factory for the SpectrumPropagationLossModel objects
   ObjectFactory m_pathlossModelFactory; //!< the factory for the PathLossModel objects

--- a/src/millicar/helper/mmwave-vehicular-helper2.h
+++ b/src/millicar/helper/mmwave-vehicular-helper2.h
@@ -128,26 +128,24 @@ public:
   */
   SchedulingPatternOption_t GetSchedulingPatternOptionType () const;
 
-  /// New Methods ///
-
-  // spectrum propagation Loss model methods
-
   void SetChannelModelType (std::string type);
 
+  /**
+   * Set an attribute to the SpectrumPropagationLossModels
+   * \param name name of the attribute to set
+   * \param value value to set
+   */
   void SetChannelModelAttribute (std::string name, const AttributeValue &value);
-
-  // channel condition model methods
 
   void SetChannelConditionModelType (std::string type);
 
-  // pathloss methods
-
   void SetPathlossModelType (std::string type);
-
+  /**
+   * Get the path loss model used in the helper
+   * \return the propagation loss model 
+   */
   Ptr<PropagationLossModel> GetPathLossModel (void);
 
-  // beamforming methods
-  
   /**
    * Set the type of beamforming model to be used
    * \param type beamforming model type
@@ -163,16 +161,23 @@ public:
   
   void SetBeamformingModelAttribute (std::string name, const AttributeValue &value);
   
-  // Spectrum Channel methods
-
+  /**
+   * Set an initialized spectrum channel for the helper
+   * \param channel the channel to set 
+   */
   void SetSpectrumChannel (Ptr<ns3::SpectrumChannel> channel);
   
+  
+  /**
+   * Get the spectrum channel used in the helper
+   * \return the spectrum channel used  
+   */
   Ptr<SpectrumChannel> GetSpectrumChannel ();
 
   
-
-  
-
+  /**
+   * Initialize the mmwave channel 
+   */
   void MmWaveChannelModelInitialization (void);
 
   

--- a/src/millicar/model/mmwave-sidelink-spectrum-phy.cc
+++ b/src/millicar/model/mmwave-sidelink-spectrum-phy.cc
@@ -176,6 +176,10 @@ MmWaveSidelinkSpectrumPhy::GetRxSpectrumModel () const
 Ptr<AntennaModel>
 MmWaveSidelinkSpectrumPhy::GetRxAntenna ()
 {
+  if(m_useGppAntenna)
+  {
+    return 0;
+  }
   return m_antenna;
 }
 
@@ -608,6 +612,13 @@ MmWaveSidelinkSpectrumPhy::ConfigureBeamforming (Ptr<NetDevice> dev)
     // vectors each time
     antennaArray->SetBeamformingVectorPanelDevices (m_device, dev);
   }
+
+  Ptr<ThreeGppAntennaArrayModel> threeGppAntennaArray = DynamicCast<ThreeGppAntennaArrayModel> (m_threeGppAntenna);
+  if (m_useGppAntenna && threeGppAntennaArray)
+  {
+    m_beamforming->SetBeamformingVectorForDevice (dev, threeGppAntennaArray);
+  }
+
 }
 
 void
@@ -618,9 +629,36 @@ MmWaveSidelinkSpectrumPhy::SetErrorModelType (TypeId errorModelType)
   m_errorModelType = errorModelType;
 }
 
+/// New Methods ///
+
 void
 MmWaveSidelinkSpectrumPhy::UseGppAntenna(bool useGppAntenna)
 {
   m_useGppAntenna = useGppAntenna;
 }
 
+
+void
+MmWaveSidelinkSpectrumPhy::SetThreeGppAntenna (Ptr<ThreeGppAntennaArrayModel> a)
+{
+  NS_ABORT_MSG_IF (!m_useGppAntenna,
+                   "First enable the usage of Three Gpp Antennas with UseGppAntenna(true).");
+  
+  m_threeGppAntenna = a;
+}
+
+void
+MmWaveSidelinkSpectrumPhy::SetBeamformingModel (Ptr<mmwave::MmWaveBeamformingModel> bfModule)
+{
+  NS_LOG_FUNCTION (this);
+
+  m_beamforming = bfModule;
+}
+
+Ptr<mmwave::MmWaveBeamformingModel>
+MmWaveSidelinkSpectrumPhy::GetBeamformingModel () const
+{
+  NS_LOG_FUNCTION (this);
+
+  return m_beamforming;
+}

--- a/src/millicar/model/mmwave-sidelink-spectrum-phy.cc
+++ b/src/millicar/model/mmwave-sidelink-spectrum-phy.cc
@@ -617,3 +617,10 @@ MmWaveSidelinkSpectrumPhy::SetErrorModelType (TypeId errorModelType)
                    "The error model must be a subclass of MmWaveErrorModel!");
   m_errorModelType = errorModelType;
 }
+
+void
+MmWaveSidelinkSpectrumPhy::UseGppAntenna(bool useGppAntenna)
+{
+  m_useGppAntenna = useGppAntenna;
+}
+

--- a/src/millicar/model/mmwave-sidelink-spectrum-phy.cc
+++ b/src/millicar/model/mmwave-sidelink-spectrum-phy.cc
@@ -632,7 +632,7 @@ MmWaveSidelinkSpectrumPhy::SetErrorModelType (TypeId errorModelType)
 /// New Methods ///
 
 void
-MmWaveSidelinkSpectrumPhy::UseGppAntenna(bool useGppAntenna)
+MmWaveSidelinkSpectrumPhy::UseThreeGppAntenna(bool useGppAntenna)
 {
   m_useGppAntenna = useGppAntenna;
 }

--- a/src/millicar/model/mmwave-sidelink-spectrum-phy.cc
+++ b/src/millicar/model/mmwave-sidelink-spectrum-phy.cc
@@ -178,6 +178,8 @@ MmWaveSidelinkSpectrumPhy::GetRxAntenna ()
 {
   if(m_useThreeGppAntenna)
   {
+    // NOTE the antenna gain is implicitly taken into account in the channel
+    // model classes (like in MmWaveSpectrumPhy::GetRxAntenna)
     return 0;
   }
   return m_antenna;

--- a/src/millicar/model/mmwave-sidelink-spectrum-phy.cc
+++ b/src/millicar/model/mmwave-sidelink-spectrum-phy.cc
@@ -176,7 +176,7 @@ MmWaveSidelinkSpectrumPhy::GetRxSpectrumModel () const
 Ptr<AntennaModel>
 MmWaveSidelinkSpectrumPhy::GetRxAntenna ()
 {
-  if(m_useGppAntenna)
+  if(m_useThreeGppAntenna)
   {
     return 0;
   }
@@ -614,7 +614,7 @@ MmWaveSidelinkSpectrumPhy::ConfigureBeamforming (Ptr<NetDevice> dev)
   }
 
   Ptr<ThreeGppAntennaArrayModel> threeGppAntennaArray = DynamicCast<ThreeGppAntennaArrayModel> (m_threeGppAntenna);
-  if (m_useGppAntenna && threeGppAntennaArray)
+  if (m_useThreeGppAntenna && threeGppAntennaArray)
   {
     m_beamforming->SetBeamformingVectorForDevice (dev, threeGppAntennaArray);
   }
@@ -634,14 +634,14 @@ MmWaveSidelinkSpectrumPhy::SetErrorModelType (TypeId errorModelType)
 void
 MmWaveSidelinkSpectrumPhy::UseThreeGppAntenna(bool useGppAntenna)
 {
-  m_useGppAntenna = useGppAntenna;
+  m_useThreeGppAntenna = useGppAntenna;
 }
 
 
 void
 MmWaveSidelinkSpectrumPhy::SetThreeGppAntenna (Ptr<ThreeGppAntennaArrayModel> a)
 {
-  NS_ABORT_MSG_IF (!m_useGppAntenna,
+  NS_ABORT_MSG_IF (!m_useThreeGppAntenna,
                    "First enable the usage of Three Gpp Antennas with UseGppAntenna(true).");
   
   m_threeGppAntenna = a;

--- a/src/millicar/model/mmwave-sidelink-spectrum-phy.h
+++ b/src/millicar/model/mmwave-sidelink-spectrum-phy.h
@@ -42,6 +42,9 @@
 #include "ns3/mmwave-control-messages.h"
 #include <ns3/mmwave-error-model.h>
 
+#include <ns3/three-gpp-antenna-array-model.h>
+#include <ns3/mmwave-beamforming-model.h>
+
 namespace ns3 {
 
 namespace millicar {
@@ -260,6 +263,10 @@ public:
   */
   void SetErrorModelType (TypeId errorModelType);
 
+  /// New Methods ///
+  
+  void UseGppAntenna(bool useGppAntenna);
+
 private:
   /**
   * \brief Change state function
@@ -311,6 +318,9 @@ private:
   //EventId m_endRxCtrlEvent;
   
   TypeId m_errorModelType; //!< the type id of the error model
+
+  bool m_useGppAntenna; //flag to indicate if gpp antenna is used
+  Ptr<mmwave::MmWaveBeamformingModel> m_beamforming; //!< used to compute the beamforming vector
 
 };
 

--- a/src/millicar/model/mmwave-sidelink-spectrum-phy.h
+++ b/src/millicar/model/mmwave-sidelink-spectrum-phy.h
@@ -262,15 +262,30 @@ public:
   * \param errorModelType type id of the error model to be used
   */
   void SetErrorModelType (TypeId errorModelType);
-
-  /// New Methods ///
   
-  void UseGppAntenna(bool useGppAntenna);
-
+  /**
+   * Set a boolean flag to use three gpp antennas 
+   * \param useGppAntenna a boolean flag to set if a gpp antenna is in use
+   */
+  void UseThreeGppAntenna(bool useGppAntenna);
+  
+  /**
+   * set the ThreeGppAntennaArrayModel to be used
+   *
+   * \param a the Antenna Model
+   */
   void SetThreeGppAntenna (Ptr<ThreeGppAntennaArrayModel> a);
   
+  /**
+   * Set the beamforming module
+   * \param bfModule the beamforming module
+   */
   void SetBeamformingModel (Ptr<mmwave::MmWaveBeamformingModel> bfModule);
-  
+
+  /**
+   * Returns the beamforming module
+   * \return the beamforming module
+   */
   Ptr<mmwave::MmWaveBeamformingModel> GetBeamformingModel () const;
 
 private:

--- a/src/millicar/model/mmwave-sidelink-spectrum-phy.h
+++ b/src/millicar/model/mmwave-sidelink-spectrum-phy.h
@@ -340,7 +340,7 @@ private:
   
   TypeId m_errorModelType; //!< the type id of the error model
 
-  bool m_useGppAntenna; //flag to indicate if gpp antenna is used
+  bool m_useThreeGppAntenna; //flag to indicate if gpp antenna is used
   Ptr<ThreeGppAntennaArrayModel> m_threeGppAntenna; ///< the three gpp antenna model
   Ptr<mmwave::MmWaveBeamformingModel> m_beamforming; //!< used to compute the beamforming vector
 

--- a/src/millicar/model/mmwave-sidelink-spectrum-phy.h
+++ b/src/millicar/model/mmwave-sidelink-spectrum-phy.h
@@ -267,6 +267,12 @@ public:
   
   void UseGppAntenna(bool useGppAntenna);
 
+  void SetThreeGppAntenna (Ptr<ThreeGppAntennaArrayModel> a);
+  
+  void SetBeamformingModel (Ptr<mmwave::MmWaveBeamformingModel> bfModule);
+  
+  Ptr<mmwave::MmWaveBeamformingModel> GetBeamformingModel () const;
+
 private:
   /**
   * \brief Change state function
@@ -320,6 +326,7 @@ private:
   TypeId m_errorModelType; //!< the type id of the error model
 
   bool m_useGppAntenna; //flag to indicate if gpp antenna is used
+  Ptr<ThreeGppAntennaArrayModel> m_threeGppAntenna; ///< the three gpp antenna model
   Ptr<mmwave::MmWaveBeamformingModel> m_beamforming; //!< used to compute the beamforming vector
 
 };

--- a/src/millicar/wscript
+++ b/src/millicar/wscript
@@ -19,6 +19,7 @@ def build(bld):
         'model/mmwave-vehicular-net-device.cc',
         'model/mmwave-vehicular-antenna-array-model.cc',
         'helper/mmwave-vehicular-helper.cc',
+        'helper/mmwave-vehicular-helper2.cc',
         'helper/mmwave-vehicular-traces-helper.cc'
         ]
 
@@ -43,6 +44,7 @@ def build(bld):
         'model/mmwave-vehicular-net-device.h',
         'model/mmwave-vehicular-antenna-array-model.h',
         'helper/mmwave-vehicular-helper.h',
+        'helper/mmwave-vehicular-helper2.h',
         'helper/mmwave-vehicular-traces-helper.h'
         ]
 

--- a/src/mmwave/helper/mmwave-helper.cc
+++ b/src/mmwave/helper/mmwave-helper.cc
@@ -2796,5 +2796,12 @@ MmWaveHelper::SetUeComponentCarrierManagerType (std::string type)
   m_ueComponentCarrierManagerFactory.SetTypeId (type);
 }
 
+Ptr<SpectrumChannel> 
+MmWaveHelper::GetSpectrumChannel(u_int8_t index)
+{
+  NS_LOG_FUNCTION (this);
+  return m_channel [index]; //return the index channel of the ccmap
+}
+
 }
 }

--- a/src/mmwave/helper/mmwave-helper.h
+++ b/src/mmwave/helper/mmwave-helper.h
@@ -321,7 +321,14 @@ public:
   void EnableUlPhyTrace ();
   void EnableEnbSchedTrace ();
 
+  /**
+   * Get a spectrum channel used in the CC map.
+   *
+   * \param index of the channel of the CCmap
+   */
   
+  Ptr<SpectrumChannel> GetSpectrumChannel(u_int8_t index);
+
 protected:
   virtual void DoInitialize ();
 

--- a/throughput_epc_plot.py
+++ b/throughput_epc_plot.py
@@ -1,0 +1,51 @@
+import re
+import matplotlib.pyplot as plt
+
+
+throughput_f = open("epc_throughput.txt")
+throughput_ls = throughput_f.readlines()[::1]
+throughput_ls = throughput_ls[2:160]
+throuhgput = []
+time = []
+
+time_pt = re.compile("^(.+?) ")
+th_pt = re.compile(" , (.+?) ")
+
+
+for line in throughput_ls:
+  #print(th_pt.findall(line))
+  throuhgput.append(float(th_pt.findall(line)[0]))
+  time.append(float(time_pt.findall(line)[0]))
+
+
+throughput_f2 = open("epc_throughput2.txt")
+throughput_ls2 = throughput_f2.readlines()[::1]
+throughput_ls2 = throughput_ls2[2:160]
+
+throuhgput2 = []
+time2 = []
+
+time_pt = re.compile("^(.+?) ")
+th_pt = re.compile(" , (.+?) ")
+
+
+for line in throughput_ls2:
+  #print(th_pt.findall(line))
+  throuhgput2.append(float(th_pt.findall(line)[0]))
+  time2.append(float(time_pt.findall(line)[0]))
+
+
+
+plt.figure()
+plt.plot(time, throuhgput, alpha=0.7, label="Throughput Vehicular Device 1")
+plt.plot(time2, throuhgput2, alpha=0.7, label="Throughput Vehicular Device 2")
+plt.legend()
+
+plt.ylabel("Throughput [Mbps]")
+plt.xlabel("Time [s]")
+#plt.title("Throughput, $x_{eNB}= x_{UE} = 80m, x_{UE}=-y_{eNB}=5m$")
+plt.show()
+
+
+#plt.plot(time, throuhgput)
+#plt.show()

--- a/throughput_video_plot.py
+++ b/throughput_video_plot.py
@@ -1,0 +1,23 @@
+import re
+import matplotlib.pyplot as plt
+
+
+throughput_f = open("video_throughput.txt")
+throughput_ls = throughput_f.readlines()
+
+throuhgput = []
+time = []
+
+time_pt = re.compile("^(.+?) ")
+th_pt = re.compile(" , (.+?) ")
+
+
+for line in throughput_ls:
+  print(th_pt.findall(line))
+  throuhgput.append(float(th_pt.findall(line)[0]))
+  time.append(float(time_pt.findall(line)[0]))
+  
+print(throuhgput)
+
+plt.plot(time, throuhgput)
+plt.show()


### PR DESCRIPTION
- I created the helper _MmWaveVehicularHelper2_ to be able to setup _millicar_ devices using a _SpectrumChannel_ with _ThreeGppSpectrumPropagationLossModel_ installed. This channel is setup during installation or can be provided through _SetSpectrumChannel_. This helper allows the creation of simulations where the channel is shared by _mmwave_ (V2I scenarios) and _millicar_ (V2V scenarios) devices. 

- I added the support to _ThreeGppAntennaArrayModel_ in _MmSidelinkSpectrumPhy_ istances. This is necessary to install a _ThreeGppAntennaArrayModel_ antenna in a _MmSidelinkSpectrumPhy_ istance. To setup a 3GPP antenna, the boolean member _m_useThreeGppAntenna_ should be set to true through the method _UseThreeGppAntenna(true)_. This flag is necessary to perform the correct beamforming (in _ConfigureBeamforming_) and return the correct antenna (in _GetRxAntenna_).  

- The simulation example _src/millicar/examples/v2x-example.cc_ shows an example of the usage of _MmWaveVehicularHelper2_. The script is a union of _mmwave-example.cc_ (from _mmwave_) and vehicular-simple-one.cc (from _millicar_), but the devices shares the same _MultiModelSpectrumChannel_ using different _SpectrumPhy_ models.